### PR TITLE
test: PROGMEM case names + expand conformance suite

### DIFF
--- a/include/navtest/navtest.h
+++ b/include/navtest/navtest.h
@@ -218,19 +218,37 @@ typedef struct {
   navtest_hook_t between; /* optional: runs between cases; NULL for none */
 } navtest_suite_t;
 
-/* Plain stringification — case.name stays in RAM on AVR.
+/* On AVR, case names live in PROGMEM: each test file declares one
+ * static const char[] per case via NAVTEST_CASE_DECL(fn), and
+ * NAVTEST_CASE(fn) points at it. Two-macro split is forced by the
+ * language — _NT_PSTR expands to a statement-expression and can't
+ * appear in a file-scope initializer, so the PROGMEM slot has to be
+ * a named array declared at file scope first.
  *
- * Wrapping #f in _NT_PSTR would have put case names in PROGMEM (~440
- * bytes saved for the conformance suite), but _NT_PSTR expands to a
- * GCC statement-expression and those aren't allowed in file-scope
- * static const initializers, where NAVTEST_CASE is used. The
- * workaround (predeclare a named PROGMEM array per case) would
- * require every test file to add NAVTEST_CASE_DECL(test_xxx) for
- * each case — verbose enough to defer until it actually pinches.
- * The assertion macros above PROGMEM their __FILE__ and message
- * strings; together with __FILE__ deduplication within a TU that
- * saves ~330 bytes of .data on AVR — enough to fit conformance. */
-#define NAVTEST_CASE(f) {(f), #f}
+ * On every other arch, NAVTEST_CASE_DECL collapses to an inert
+ * declaration (so the trailing ';' is still valid) and NAVTEST_CASE
+ * uses plain stringification.
+ *
+ * navtest_run_suite reads c->name via navtest_write_P, which is the
+ * AVR PROGMEM reader on AVR and #defined to navtest_write everywhere
+ * else — so the suite walker is portable as-is.
+ *
+ * Usage:
+ *   NAVTEST_CASE_DECL(test_foo);
+ *   NAVTEST_CASE_DECL(test_bar);
+ *   static const navtest_case_t cases[] = {
+ *     NAVTEST_CASE(test_foo),
+ *     NAVTEST_CASE(test_bar),
+ *   };
+ */
+#if defined(__AVR__)
+#  define NAVTEST_CASE_DECL(fn)                                                \
+     static const char _navtest_name_##fn[] __attribute__((__progmem__)) = #fn
+#  define NAVTEST_CASE(fn) {(fn), _navtest_name_##fn}
+#else
+#  define NAVTEST_CASE_DECL(fn) extern const char _navtest_unused_##fn[]
+#  define NAVTEST_CASE(fn) {(fn), #fn}
+#endif
 
 /** Run every case in @p suite, printing a banner + summary. Returns failures. */
 int navtest_run_suite(const navtest_suite_t *suite);

--- a/tests/arch/cortex-m4/test_clock.c
+++ b/tests/arch/cortex-m4/test_clock.c
@@ -186,6 +186,20 @@ void test_hal_clock_init_pll_rejects_null_pll_cfg(void) {
   TEST_ASSERT_EQUAL_UINT32((uint32_t)HAL_ERR_INVALID_ARG,
                            (uint32_t)hal_clock_init(&cfg, NULL));
 }
+/* PROGMEM slot for each case name on AVR; no-op elsewhere. */
+NAVTEST_CASE_DECL(test_hal_clock_init_hsi);
+NAVTEST_CASE_DECL(test_hal_clock_init_hse);
+NAVTEST_CASE_DECL(test_hal_clock_init_pll);
+NAVTEST_CASE_DECL(test_hal_clock_get_sysclk_returns_correct_value_hsi);
+NAVTEST_CASE_DECL(test_hal_clock_get_sysclk_returns_correct_value_hse);
+NAVTEST_CASE_DECL(test_hal_clock_get_sysclk_returns_correct_value_pll);
+NAVTEST_CASE_DECL(test_hal_clock_get_ahbclk_returns_correct_value);
+NAVTEST_CASE_DECL(test_hal_clock_get_apb1clk_returns_correct_value);
+NAVTEST_CASE_DECL(test_hal_clock_get_apb2clk_returns_correct_value);
+NAVTEST_CASE_DECL(test_hal_clock_init_returns_ok_for_hsi);
+NAVTEST_CASE_DECL(test_hal_clock_init_rejects_null_cfg);
+NAVTEST_CASE_DECL(test_hal_clock_init_pll_rejects_null_pll_cfg);
+
 
 static const navtest_case_t clock_cases[] = {
     NAVTEST_CASE(test_hal_clock_init_hsi),

--- a/tests/arch/cortex-m4/test_gpio.c
+++ b/tests/arch/cortex-m4/test_gpio.c
@@ -170,6 +170,19 @@ void test_hal_gpio_init_rejects_null_config(void) {
 }
 
 /* -------------------- Suite -------------------- */
+/* PROGMEM slot for each case name on AVR; no-op elsewhere. */
+NAVTEST_CASE_DECL(test_hal_gpio_init_applies_config);
+NAVTEST_CASE_DECL(test_hal_gpio_set_mode_writes_moder);
+NAVTEST_CASE_DECL(test_hal_gpio_get_mode_round_trip);
+NAVTEST_CASE_DECL(test_hal_gpio_enable_clock_sets_ahb1_bit);
+NAVTEST_CASE_DECL(test_hal_gpio_set_alternate_function_writes_af);
+NAVTEST_CASE_DECL(test_hal_gpio_set_alternate_function_switches_mode_to_af);
+NAVTEST_CASE_DECL(test_hal_gpio_set_output_type_writes_otyper);
+NAVTEST_CASE_DECL(test_hal_gpio_set_output_speed_writes_ospeedr);
+NAVTEST_CASE_DECL(test_hal_gpio_write_high_then_low);
+NAVTEST_CASE_DECL(test_hal_gpio_toggle_flips_state);
+NAVTEST_CASE_DECL(test_hal_gpio_init_rejects_null_config);
+
 
 static const navtest_case_t gpio_cases[] = {
     NAVTEST_CASE(test_hal_gpio_init_applies_config),

--- a/tests/arch/cortex-m4/test_i2c.c
+++ b/tests/arch/cortex-m4/test_i2c.c
@@ -100,6 +100,16 @@ void test_hal_i2c_typed_id_compiles(void) {
   (void)hal_i2c_write(bus, 0x50, &data, 0);
   TEST_ASSERT_TRUE(1);
 }
+/* PROGMEM slot for each case name on AVR; no-op elsewhere. */
+NAVTEST_CASE_DECL(test_i2c_init_config);
+NAVTEST_CASE_DECL(test_i2c_fast_mode_config);
+NAVTEST_CASE_DECL(test_hal_i2c_init_returns_ok);
+NAVTEST_CASE_DECL(test_hal_i2c_init_rejects_null_config);
+NAVTEST_CASE_DECL(test_hal_i2c_write_rejects_null_data);
+NAVTEST_CASE_DECL(test_hal_i2c_read_rejects_null_data);
+NAVTEST_CASE_DECL(test_hal_i2c_write_read_rejects_null_data);
+NAVTEST_CASE_DECL(test_hal_i2c_typed_id_compiles);
+
 
 static const navtest_case_t i2c_cases[] = {
     NAVTEST_CASE(test_i2c_init_config),

--- a/tests/arch/cortex-m4/test_interrupt.c
+++ b/tests/arch/cortex-m4/test_interrupt.c
@@ -159,6 +159,22 @@ void test_hal_interrupt_detach_rejects_out_of_range(void) {
 }
 
 /* -------------------- Suite -------------------- */
+/* PROGMEM slot for each case name on AVR; no-op elsewhere. */
+NAVTEST_CASE_DECL(test_hal_interrupt_enable_sets_iser_bit);
+NAVTEST_CASE_DECL(test_hal_interrupt_disable_sets_icer_bit);
+NAVTEST_CASE_DECL(test_hal_interrupt_clear_pending_clears_ispr_bit);
+NAVTEST_CASE_DECL(test_hal_interrupt_set_get_priority_round_trip);
+NAVTEST_CASE_DECL(test_hal_interrupt_is_pending_after_set);
+NAVTEST_CASE_DECL(test_hal_interrupt_attach_then_dispatch_runs_callback);
+NAVTEST_CASE_DECL(test_hal_interrupt_detach_clears_callback);
+NAVTEST_CASE_DECL(test_hal_interrupt_disable_then_restore_global);
+NAVTEST_CASE_DECL(test_hal_interrupt_clear_all_pending_zeros_icpr);
+NAVTEST_CASE_DECL(test_hal_interrupt_enable_rejects_negative_irq);
+NAVTEST_CASE_DECL(test_hal_interrupt_disable_rejects_negative_irq);
+NAVTEST_CASE_DECL(test_hal_interrupt_clear_pending_rejects_negative_irq);
+NAVTEST_CASE_DECL(test_hal_interrupt_attach_rejects_out_of_range);
+NAVTEST_CASE_DECL(test_hal_interrupt_detach_rejects_out_of_range);
+
 
 static const navtest_case_t interrupt_cases[] = {
     NAVTEST_CASE(test_hal_interrupt_enable_sets_iser_bit),

--- a/tests/arch/cortex-m4/test_pwm.c
+++ b/tests/arch/cortex-m4/test_pwm.c
@@ -148,6 +148,19 @@ void test_hal_pwm_set_frequency_rejects_null_handle(void) {
       (uint32_t)HAL_ERR_INVALID_ARG,
       (uint32_t)hal_pwm_set_frequency(NULL, 1000));
 }
+/* PROGMEM slot for each case name on AVR; no-op elsewhere. */
+NAVTEST_CASE_DECL(test_hal_pwm_init_apb1);
+NAVTEST_CASE_DECL(test_hal_pwm_init_apb2);
+NAVTEST_CASE_DECL(test_hal_pwm_start_sets_counter_enable);
+NAVTEST_CASE_DECL(test_hal_pwm_stop_clears_counter_enable);
+NAVTEST_CASE_DECL(test_hal_pwm_set_duty_cycle_updates_ccr);
+NAVTEST_CASE_DECL(test_hal_pwm_init_rejects_null_handle);
+NAVTEST_CASE_DECL(test_hal_pwm_start_rejects_null_handle);
+NAVTEST_CASE_DECL(test_hal_pwm_stop_rejects_null_handle);
+NAVTEST_CASE_DECL(test_hal_pwm_set_duty_cycle_rejects_null_handle);
+NAVTEST_CASE_DECL(test_hal_pwm_set_frequency_returns_ok);
+NAVTEST_CASE_DECL(test_hal_pwm_set_frequency_rejects_null_handle);
+
 
 static const navtest_case_t pwm_cases[] = {
     NAVTEST_CASE(test_hal_pwm_init_apb1),

--- a/tests/arch/cortex-m4/test_spi.c
+++ b/tests/arch/cortex-m4/test_spi.c
@@ -98,6 +98,15 @@ void test_hal_spi_init_cpol_low_cpha_1edge(void) {
   TEST_ASSERT_FALSE(S1->CR1 & SPI_CR1_DFF);
   TEST_ASSERT_FALSE(S1->CR1 & SPI_CR1_LSBFIRST);
 }
+/* PROGMEM slot for each case name on AVR; no-op elsewhere. */
+NAVTEST_CASE_DECL(test_spi_init_config);
+NAVTEST_CASE_DECL(test_hal_spi_init_returns_ok);
+NAVTEST_CASE_DECL(test_hal_spi_init_rejects_null_config);
+NAVTEST_CASE_DECL(test_hal_spi_transmit_rejects_null_data);
+NAVTEST_CASE_DECL(test_hal_spi_receive_rejects_null_data);
+NAVTEST_CASE_DECL(test_hal_spi_transmit_receive_rejects_null_data);
+NAVTEST_CASE_DECL(test_hal_spi_init_cpol_low_cpha_1edge);
+
 
 static const navtest_case_t spi_cases[] = {
     NAVTEST_CASE(test_spi_init_config),

--- a/tests/arch/cortex-m4/test_timer.c
+++ b/tests/arch/cortex-m4/test_timer.c
@@ -218,6 +218,23 @@ void test_hal_timer_attach_then_detach_callback(void) {
   TEST_ASSERT_EQUAL_UINT32(
       (uint32_t)HAL_OK, (uint32_t)hal_timer_detach_callback(TEST_TIMER));
 }
+/* PROGMEM slot for each case name on AVR; no-op elsewhere. */
+NAVTEST_CASE_DECL(test_timer_init_sets_prescaler_and_arr);
+NAVTEST_CASE_DECL(test_timer_start_sets_CEN_bit);
+NAVTEST_CASE_DECL(test_timer_stop_clears_CEN_bit);
+NAVTEST_CASE_DECL(test_timer_reset_clears_count);
+NAVTEST_CASE_DECL(test_timer_set_compare_and_get_compare);
+NAVTEST_CASE_DECL(test_timer_enable_and_disable_channel);
+NAVTEST_CASE_DECL(test_timer_clear_interrupt_flag_clears_UIF);
+NAVTEST_CASE_DECL(test_timer_set_arr_and_get_arr);
+NAVTEST_CASE_DECL(test_timer_get_count_returns_correct_value);
+NAVTEST_CASE_DECL(test_timer_get_frequency_returns_correct_value);
+NAVTEST_CASE_DECL(test_hal_timer_init_rejects_null_config);
+NAVTEST_CASE_DECL(test_hal_timer_init_freq_returns_ok);
+NAVTEST_CASE_DECL(test_hal_timer_set_prescaler_round_trip);
+NAVTEST_CASE_DECL(test_hal_timer_set_get_auto_reload);
+NAVTEST_CASE_DECL(test_hal_timer_attach_then_detach_callback);
+
 
 static const navtest_case_t timer_cases[] = {
     NAVTEST_CASE(test_timer_init_sets_prescaler_and_arr),

--- a/tests/arch/cortex-m4/test_uart_protocol.c
+++ b/tests/arch/cortex-m4/test_uart_protocol.c
@@ -140,6 +140,20 @@ void test_hal_uart_available_after_init_is_false(void) {
   init_test_uart(115200);
   TEST_ASSERT_FALSE(hal_uart_available(TEST_UART));
 }
+/* PROGMEM slot for each case name on AVR; no-op elsewhere. */
+NAVTEST_CASE_DECL(test_uart_baudrate_9600);
+NAVTEST_CASE_DECL(test_uart_baudrate_115200);
+NAVTEST_CASE_DECL(test_hal_uart_init_returns_ok);
+NAVTEST_CASE_DECL(test_hal_uart_init_rejects_null_config);
+NAVTEST_CASE_DECL(test_hal_uart_write_returns_ok);
+NAVTEST_CASE_DECL(test_hal_uart_write_char_returns_ok);
+NAVTEST_CASE_DECL(test_hal_uart_write_int_returns_ok);
+NAVTEST_CASE_DECL(test_hal_uart_write_uint_returns_ok);
+NAVTEST_CASE_DECL(test_hal_uart_write_float_returns_ok);
+NAVTEST_CASE_DECL(test_hal_uart_write_string_returns_ok);
+NAVTEST_CASE_DECL(test_hal_uart_print_generic_dispatch);
+NAVTEST_CASE_DECL(test_hal_uart_available_after_init_is_false);
+
 
 static const navtest_case_t uart_protocol_cases[] = {
     NAVTEST_CASE(test_uart_baudrate_9600),

--- a/tests/cap/cycle_counter/test_dwt.c
+++ b/tests/cap/cycle_counter/test_dwt.c
@@ -88,6 +88,14 @@ void test_hal_cycle_counter_reset_returns_ok(void) {
   TEST_ASSERT_EQUAL_UINT32((uint32_t)HAL_OK,
                            (uint32_t)hal_cycle_counter_reset());
 }
+/* PROGMEM slot for each case name on AVR; no-op elsewhere. */
+NAVTEST_CASE_DECL(test_dwt_init_enables_counters);
+NAVTEST_CASE_DECL(test_dwt_get_cycles_increments);
+NAVTEST_CASE_DECL(test_dwt_reset_cycles_zeros_counter);
+NAVTEST_CASE_DECL(test_dwt_delay_cycles_elapses_time);
+NAVTEST_CASE_DECL(test_hal_cycle_counter_init_returns_ok);
+NAVTEST_CASE_DECL(test_hal_cycle_counter_reset_returns_ok);
+
 
 static const navtest_case_t dwt_cases[] = {
     NAVTEST_CASE(test_dwt_init_enables_counters),

--- a/tests/cap/dma/test_dma.c
+++ b/tests/cap/dma/test_dma.c
@@ -189,6 +189,25 @@ void test_hal_dma_stop_rejects_null_config(void) {
   TEST_ASSERT_EQUAL_UINT32((uint32_t)HAL_ERR_INVALID_ARG,
                            (uint32_t)hal_dma_stop(NULL));
 }
+/* PROGMEM slot for each case name on AVR; no-op elsewhere. */
+NAVTEST_CASE_DECL(test_dma_clock_enable_dma1);
+NAVTEST_CASE_DECL(test_dma_clock_enable_dma2);
+NAVTEST_CASE_DECL(test_dma_init_sets_channel);
+NAVTEST_CASE_DECL(test_dma_init_sets_direction_m2p);
+NAVTEST_CASE_DECL(test_dma_init_sets_direction_p2m);
+NAVTEST_CASE_DECL(test_dma_init_sets_minc);
+NAVTEST_CASE_DECL(test_dma_init_sets_priority);
+NAVTEST_CASE_DECL(test_dma_init_sets_ndtr);
+NAVTEST_CASE_DECL(test_dma_init_sets_peripheral_address);
+NAVTEST_CASE_DECL(test_dma_init_sets_memory_address);
+NAVTEST_CASE_DECL(test_dma_start_enables_stream);
+NAVTEST_CASE_DECL(test_dma_stop_disables_stream);
+NAVTEST_CASE_DECL(test_dma_transfer_complete_returns_zero_before_start);
+NAVTEST_CASE_DECL(test_dma_clear_flags_clears_isr);
+NAVTEST_CASE_DECL(test_hal_dma_init_rejects_null_config);
+NAVTEST_CASE_DECL(test_hal_dma_start_rejects_null_config);
+NAVTEST_CASE_DECL(test_hal_dma_stop_rejects_null_config);
+
 
 static const navtest_case_t dma_cases[] = {
     NAVTEST_CASE(test_dma_clock_enable_dma1),

--- a/tests/cap/fpu/test_fpu_accel.c
+++ b/tests/cap/fpu/test_fpu_accel.c
@@ -67,6 +67,11 @@ void test_fpu_benchmark_cycles(void) {
 void test_hal_fpu_enable_returns_ok(void) {
   TEST_ASSERT_EQUAL_UINT32((uint32_t)HAL_OK, (uint32_t)hal_fpu_enable());
 }
+/* PROGMEM slot for each case name on AVR; no-op elsewhere. */
+NAVTEST_CASE_DECL(test_fpu_basic_arithmetic);
+NAVTEST_CASE_DECL(test_fpu_benchmark_cycles);
+NAVTEST_CASE_DECL(test_hal_fpu_enable_returns_ok);
+
 
 static const navtest_case_t fpu_cases[] = {
     NAVTEST_CASE(test_fpu_basic_arithmetic),

--- a/tests/cap/sdio/test_sdio.c
+++ b/tests/cap/sdio/test_sdio.c
@@ -73,6 +73,13 @@ void test_hal_sdio_set_callback_smoke(void) {
   hal_sdio_set_callback(NULL); /* re-clear */
   TEST_ASSERT_TRUE(1);
 }
+/* PROGMEM slot for each case name on AVR; no-op elsewhere. */
+NAVTEST_CASE_DECL(test_hal_sdio_init_rejects_null_config);
+NAVTEST_CASE_DECL(test_hal_sdio_read_block_rejects_null_buffer);
+NAVTEST_CASE_DECL(test_hal_sdio_write_block_rejects_null_buffer);
+NAVTEST_CASE_DECL(test_hal_sdio_get_sector_count_returns_value);
+NAVTEST_CASE_DECL(test_hal_sdio_set_callback_smoke);
+
 
 static const navtest_case_t sdio_cases[] = {
     NAVTEST_CASE(test_hal_sdio_init_rejects_null_config),

--- a/tests/host/test_conversion.c
+++ b/tests/host/test_conversion.c
@@ -71,6 +71,17 @@ void test_str_to_float_with_decimal(void) {
 void test_str_to_float_negative(void) {
   TEST_ASSERT_TRUE(float_near(-2.5f, str_to_float("-2.5")));
 }
+/* PROGMEM slot for each case name on AVR; no-op elsewhere. */
+NAVTEST_CASE_DECL(test_str_to_int_basic);
+NAVTEST_CASE_DECL(test_str_to_int_negative);
+NAVTEST_CASE_DECL(test_str_to_int_plus_sign);
+NAVTEST_CASE_DECL(test_str_to_int_leading_whitespace);
+NAVTEST_CASE_DECL(test_str_to_int_stops_at_non_digit);
+NAVTEST_CASE_DECL(test_str_to_int_empty_string);
+NAVTEST_CASE_DECL(test_str_to_float_basic);
+NAVTEST_CASE_DECL(test_str_to_float_with_decimal);
+NAVTEST_CASE_DECL(test_str_to_float_negative);
+
 
 static const navtest_case_t conversion_cases[] = {
     NAVTEST_CASE(test_str_to_int_basic),

--- a/tests/host/test_crc_sw.c
+++ b/tests/host/test_crc_sw.c
@@ -84,6 +84,14 @@ void test_crc_sw_reset_restores_init(void) {
   /* After reset, accumulating nothing yields the init value. */
   TEST_ASSERT_EQUAL_UINT32(0xFFFFFFFFu, hal_crc_accumulate(NULL, 0));
 }
+/* PROGMEM slot for each case name on AVR; no-op elsewhere. */
+NAVTEST_CASE_DECL(test_crc_sw_init_rejects_null);
+NAVTEST_CASE_DECL(test_crc_sw_empty_returns_init);
+NAVTEST_CASE_DECL(test_crc_sw_single_byte);
+NAVTEST_CASE_DECL(test_crc_sw_mpeg2_reference_vector);
+NAVTEST_CASE_DECL(test_crc_sw_accumulate_matches_compute);
+NAVTEST_CASE_DECL(test_crc_sw_reset_restores_init);
+
 
 static const navtest_case_t crc_sw_cases[] = {
     NAVTEST_CASE(test_crc_sw_init_rejects_null),

--- a/tests/host/test_gpio_encoding.c
+++ b/tests/host/test_gpio_encoding.c
@@ -69,6 +69,12 @@ void test_gpio_get_port_number_skips_to_h(void) {
   TEST_ASSERT_EQUAL_UINT32(7, GPIO_GET_PORT_NUMBER(GPIO_PH00));
   TEST_ASSERT_EQUAL_UINT32(7, GPIO_GET_PORT_NUMBER(GPIO_PH09));
 }
+/* PROGMEM slot for each case name on AVR; no-op elsewhere. */
+NAVTEST_CASE_DECL(test_gpio_pin_encoding_layout);
+NAVTEST_CASE_DECL(test_gpio_get_pin_returns_low_nibble);
+NAVTEST_CASE_DECL(test_gpio_get_port_number_for_a_through_e);
+NAVTEST_CASE_DECL(test_gpio_get_port_number_skips_to_h);
+
 
 static const navtest_case_t gpio_encoding_cases[] = {
     NAVTEST_CASE(test_gpio_pin_encoding_layout),

--- a/tests/host/test_hal_status.c
+++ b/tests/host/test_hal_status.c
@@ -86,6 +86,13 @@ void test_hal_ok_or_return_short_circuits(void) {
   TEST_ASSERT_EQUAL_UINT32((uint32_t)HAL_ERR_TIMEOUT, (uint32_t)got);
   TEST_ASSERT_EQUAL_UINT32(1, (uint32_t)s); /* stopped after the OK call */
 }
+/* PROGMEM slot for each case name on AVR; no-op elsewhere. */
+NAVTEST_CASE_DECL(test_hal_status_ok_is_zero);
+NAVTEST_CASE_DECL(test_hal_status_err_is_one);
+NAVTEST_CASE_DECL(test_hal_status_distinct_codes);
+NAVTEST_CASE_DECL(test_hal_ok_or_return_passes_through);
+NAVTEST_CASE_DECL(test_hal_ok_or_return_short_circuits);
+
 
 static const navtest_case_t hal_status_cases[] = {
     NAVTEST_CASE(test_hal_status_ok_is_zero),

--- a/tests/navtest_state.c
+++ b/tests/navtest_state.c
@@ -64,11 +64,13 @@ __attribute__((weak)) void tearDown(void) {}
 /* Walk a suite's case table, printing per-suite banners + summary.
  * Identical per-case output to RUN_TEST.
  *
- * Suite + case names come from test files' static initializers and
- * are RAM-resident on every arch (NAVTEST_CASE uses plain #f
- * stringification — see comment in navtest.h). The literals
- * bracketing the names DO go through navtest_write_P + _NT_PSTR so
- * they land in PROGMEM on AVR. */
+ * Case names live in PROGMEM on AVR (NAVTEST_CASE_DECL declares each
+ * one as a static const char[] __progmem__) and in .rodata everywhere
+ * else. navtest_write_P aliases navtest_write on non-AVR, so reading
+ * c->name through it is portable.
+ *
+ * Suite names are still RAM string literals — short, few per build,
+ * not worth a parallel _DECL macro. */
 int navtest_run_suite(const navtest_suite_t *suite) {
   navtest_write_P(_NT_PSTR("\n=========== "));
   navtest_write(suite->name);
@@ -84,7 +86,7 @@ int navtest_run_suite(const navtest_suite_t *suite) {
     uint32_t prev = _navtest.failures;
     setUp();
     navtest_write_P(_NT_PSTR(_NT_CYAN "  >> " _NT_BOLD));
-    navtest_write(c->name);
+    navtest_write_P(c->name);
     navtest_write_P(_NT_PSTR(_NT_RST "\r\n"));
     c->fn();
     if (_navtest.failures == prev) {

--- a/tests/portable/conformance/test_conformance.c
+++ b/tests/portable/conformance/test_conformance.c
@@ -149,6 +149,19 @@ void test_conformance_cap_macros_are_defined(void) {
   TEST_ASSERT_TRUE(NAVHAL_HAS_CYCLE_COUNTER  == 0 || NAVHAL_HAS_CYCLE_COUNTER  == 1);
   TEST_ASSERT_TRUE(NAVHAL_HAS_SDIO           == 0 || NAVHAL_HAS_SDIO           == 1);
 }
+/* PROGMEM slot for each case name on AVR; no-op elsewhere. */
+NAVTEST_CASE_DECL(test_conformance_status_ok_is_zero);
+NAVTEST_CASE_DECL(test_conformance_status_errors_distinct);
+NAVTEST_CASE_DECL(test_conformance_gpio_init_rejects_null);
+NAVTEST_CASE_DECL(test_conformance_clock_init_rejects_null);
+NAVTEST_CASE_DECL(test_conformance_uart_init_rejects_null);
+NAVTEST_CASE_DECL(test_conformance_dma_init_rejects_null);
+NAVTEST_CASE_DECL(test_conformance_i2c_init_rejects_null);
+NAVTEST_CASE_DECL(test_conformance_spi_init_rejects_null);
+NAVTEST_CASE_DECL(test_conformance_pwm_init_rejects_null);
+NAVTEST_CASE_DECL(test_conformance_sdio_init_rejects_null);
+NAVTEST_CASE_DECL(test_conformance_cap_macros_are_defined);
+
 
 static const navtest_case_t conformance_cases[] = {
     NAVTEST_CASE(test_conformance_status_ok_is_zero),

--- a/tests/portable/conformance/test_conformance.c
+++ b/tests/portable/conformance/test_conformance.c
@@ -52,13 +52,71 @@ void test_conformance_status_ok_is_zero(void) {
 void test_conformance_status_errors_distinct(void) {
   /* No two error codes share a value. A port that aliases
    * HAL_ERR_INVALID_ARG to HAL_ERR_TIMEOUT would silently lose
-   * caller-meaningful information. */
-  TEST_ASSERT_TRUE((uint32_t)HAL_ERR_INVALID_ARG    != (uint32_t)HAL_OK);
-  TEST_ASSERT_TRUE((uint32_t)HAL_ERR_TIMEOUT        != (uint32_t)HAL_OK);
-  TEST_ASSERT_TRUE((uint32_t)HAL_ERR_NOT_SUPPORTED  != (uint32_t)HAL_OK);
-  TEST_ASSERT_TRUE((uint32_t)HAL_ERR_INVALID_ARG    != (uint32_t)HAL_ERR_TIMEOUT);
-  TEST_ASSERT_TRUE((uint32_t)HAL_ERR_INVALID_ARG    != (uint32_t)HAL_ERR_NOT_SUPPORTED);
-  TEST_ASSERT_TRUE((uint32_t)HAL_ERR_TIMEOUT        != (uint32_t)HAL_ERR_NOT_SUPPORTED);
+   * caller-meaningful information. Walks the full enum pairwise so
+   * adding a code without updating this test still catches collisions. */
+  const uint32_t codes[] = {
+      (uint32_t)HAL_OK,
+      (uint32_t)HAL_ERR,
+      (uint32_t)HAL_ERR_INVALID_ARG,
+      (uint32_t)HAL_ERR_TIMEOUT,
+      (uint32_t)HAL_ERR_BUSY,
+      (uint32_t)HAL_ERR_NOT_INITIALIZED,
+      (uint32_t)HAL_ERR_NOT_SUPPORTED,
+      (uint32_t)HAL_ERR_IO,
+      (uint32_t)HAL_ERR_NO_MEM,
+  };
+  const uint8_t n = (uint8_t)(sizeof(codes) / sizeof(codes[0]));
+  for (uint8_t i = 0; i < n; i++) {
+    for (uint8_t j = (uint8_t)(i + 1); j < n; j++) {
+      TEST_ASSERT_TRUE(codes[i] != codes[j]);
+    }
+  }
+}
+
+void test_conformance_status_fits_uint8(void) {
+  /* Wire-format / RPC ABI guarantee: a port-package may serialize a
+   * status as a single byte. A new code that grew past 255 would
+   * silently truncate on the wire. */
+  TEST_ASSERT_TRUE((uint32_t)HAL_OK                  <= 0xFFu);
+  TEST_ASSERT_TRUE((uint32_t)HAL_ERR                 <= 0xFFu);
+  TEST_ASSERT_TRUE((uint32_t)HAL_ERR_INVALID_ARG     <= 0xFFu);
+  TEST_ASSERT_TRUE((uint32_t)HAL_ERR_TIMEOUT         <= 0xFFu);
+  TEST_ASSERT_TRUE((uint32_t)HAL_ERR_BUSY            <= 0xFFu);
+  TEST_ASSERT_TRUE((uint32_t)HAL_ERR_NOT_INITIALIZED <= 0xFFu);
+  TEST_ASSERT_TRUE((uint32_t)HAL_ERR_NOT_SUPPORTED   <= 0xFFu);
+  TEST_ASSERT_TRUE((uint32_t)HAL_ERR_IO              <= 0xFFu);
+  TEST_ASSERT_TRUE((uint32_t)HAL_ERR_NO_MEM          <= 0xFFu);
+}
+
+/* HAL_OK_OR_RETURN macro contract — already covered by the host SIL
+ * suite, repeated here so every PIL run on every port exercises it
+ * against the port's real codegen (catches a port that redefined
+ * HAL_OK_OR_RETURN or shadowed _navhal_status). */
+static hal_status_t _conf_returns(hal_status_t s) {
+  HAL_OK_OR_RETURN(s);
+  return HAL_OK;
+}
+
+static int _conf_eval_counter = 0;
+static hal_status_t _conf_count_and_return(hal_status_t s) {
+  _conf_eval_counter++;
+  return s;
+}
+
+void test_conformance_hal_ok_or_return_passes_through(void) {
+  TEST_ASSERT_EQUAL_UINT32((uint32_t)HAL_OK, (uint32_t)_conf_returns(HAL_OK));
+  _conf_eval_counter = 0;
+  (void)_conf_returns(_conf_count_and_return(HAL_OK));
+  /* The macro is documented as evaluating its argument exactly once
+   * (the do-while wrapper holds the value in a local). */
+  TEST_ASSERT_EQUAL_UINT32((uint32_t)1, (uint32_t)_conf_eval_counter);
+}
+
+void test_conformance_hal_ok_or_return_short_circuits(void) {
+  TEST_ASSERT_EQUAL_UINT32((uint32_t)HAL_ERR_TIMEOUT,
+                           (uint32_t)_conf_returns(HAL_ERR_TIMEOUT));
+  TEST_ASSERT_EQUAL_UINT32((uint32_t)HAL_ERR_INVALID_ARG,
+                           (uint32_t)_conf_returns(HAL_ERR_INVALID_ARG));
 }
 
 /* -------------------------------------------------------------------------- *
@@ -118,6 +176,34 @@ void test_conformance_sdio_init_rejects_null(void) {
 #endif
 }
 
+/* Idempotency on the error path: calling init with NULL twice in a
+ * row must return the same status both times. A port that flips an
+ * internal "initialised" flag on the NULL branch would fail this. */
+void test_conformance_null_init_is_idempotent(void) {
+  hal_status_t a = hal_gpio_init((hal_gpio_pin_t)0, NULL);
+  hal_status_t b = hal_gpio_init((hal_gpio_pin_t)0, NULL);
+  TEST_ASSERT_EQUAL_UINT32((uint32_t)a, (uint32_t)b);
+
+#if NAVHAL_HAS_DMA
+  hal_status_t da = hal_dma_init(NULL);
+  hal_status_t db = hal_dma_init(NULL);
+  TEST_ASSERT_EQUAL_UINT32((uint32_t)da, (uint32_t)db);
+#endif
+
+#if NAVHAL_HAS_I2C
+  hal_status_t ia = hal_i2c_init((hal_i2c_bus_t)0, NULL);
+  hal_status_t ib = hal_i2c_init((hal_i2c_bus_t)0, NULL);
+  TEST_ASSERT_EQUAL_UINT32((uint32_t)ia, (uint32_t)ib);
+#endif
+
+#if NAVHAL_HAS_UART
+  hal_uart_t inst = (hal_uart_t)0;
+  hal_status_t ua = hal_uart_init(inst, NULL);
+  hal_status_t ub = hal_uart_init(inst, NULL);
+  TEST_ASSERT_EQUAL_UINT32((uint32_t)ua, (uint32_t)ub);
+#endif
+}
+
 /* -------------------------------------------------------------------------- *
  * Capability-flag contract — every NAVHAL_HAS_* macro must be defined
  * as a numeric 0 or 1. Source code that does `#if NAVHAL_HAS_X` relies
@@ -152,6 +238,9 @@ void test_conformance_cap_macros_are_defined(void) {
 /* PROGMEM slot for each case name on AVR; no-op elsewhere. */
 NAVTEST_CASE_DECL(test_conformance_status_ok_is_zero);
 NAVTEST_CASE_DECL(test_conformance_status_errors_distinct);
+NAVTEST_CASE_DECL(test_conformance_status_fits_uint8);
+NAVTEST_CASE_DECL(test_conformance_hal_ok_or_return_passes_through);
+NAVTEST_CASE_DECL(test_conformance_hal_ok_or_return_short_circuits);
 NAVTEST_CASE_DECL(test_conformance_gpio_init_rejects_null);
 NAVTEST_CASE_DECL(test_conformance_clock_init_rejects_null);
 NAVTEST_CASE_DECL(test_conformance_uart_init_rejects_null);
@@ -160,12 +249,16 @@ NAVTEST_CASE_DECL(test_conformance_i2c_init_rejects_null);
 NAVTEST_CASE_DECL(test_conformance_spi_init_rejects_null);
 NAVTEST_CASE_DECL(test_conformance_pwm_init_rejects_null);
 NAVTEST_CASE_DECL(test_conformance_sdio_init_rejects_null);
+NAVTEST_CASE_DECL(test_conformance_null_init_is_idempotent);
 NAVTEST_CASE_DECL(test_conformance_cap_macros_are_defined);
 
 
 static const navtest_case_t conformance_cases[] = {
     NAVTEST_CASE(test_conformance_status_ok_is_zero),
     NAVTEST_CASE(test_conformance_status_errors_distinct),
+    NAVTEST_CASE(test_conformance_status_fits_uint8),
+    NAVTEST_CASE(test_conformance_hal_ok_or_return_passes_through),
+    NAVTEST_CASE(test_conformance_hal_ok_or_return_short_circuits),
     NAVTEST_CASE(test_conformance_gpio_init_rejects_null),
     NAVTEST_CASE(test_conformance_clock_init_rejects_null),
     NAVTEST_CASE(test_conformance_uart_init_rejects_null),
@@ -174,6 +267,7 @@ static const navtest_case_t conformance_cases[] = {
     NAVTEST_CASE(test_conformance_spi_init_rejects_null),
     NAVTEST_CASE(test_conformance_pwm_init_rejects_null),
     NAVTEST_CASE(test_conformance_sdio_init_rejects_null),
+    NAVTEST_CASE(test_conformance_null_init_is_idempotent),
     NAVTEST_CASE(test_conformance_cap_macros_are_defined),
 };
 

--- a/tests/portable/conformance/test_conformance.h
+++ b/tests/portable/conformance/test_conformance.h
@@ -29,13 +29,10 @@
  * vendor-specific includes. The whole file lives under
  * tests/portable/ for exactly that reason.
  *
- * Runs on AVR too as of the navtest PROGMEM-string support (M7
- * follow-up): TEST_ASSERT_* macros now route __FILE__ + assertion
- * messages through `_NT_PSTR()` so those strings live in flash on
- * AVR rather than .data, freeing ~440 bytes of SRAM. Case names
- * (`#fn` stringification inside file-scope NAVTEST_CASE) stay in
- * RAM because GCC statement-expressions aren't allowed in static
- * initializers — see the NAVTEST_CASE comment in navtest.h.
+ * Runs on AVR too: TEST_ASSERT_* macros and case names both land in
+ * PROGMEM on AVR (assertion strings via `_NT_PSTR()`, case names via
+ * the `NAVTEST_CASE_DECL` predeclaration trick), keeping the suite
+ * well under the ATmega328P's 2 KB SRAM ceiling.
  */
 #ifndef TEST_CONFORMANCE_H
 #define TEST_CONFORMANCE_H
@@ -47,12 +44,20 @@ extern "C" {
 #endif
 
 /* Status type contract — error codes are non-zero, HAL_OK is zero,
- * codes are distinct from each other. */
+ * codes are pairwise distinct, and each fits in 8 bits (RPC ABI). */
 void test_conformance_status_ok_is_zero(void);
 void test_conformance_status_errors_distinct(void);
+void test_conformance_status_fits_uint8(void);
+
+/* HAL_OK_OR_RETURN macro contract — passes the status through on OK,
+ * short-circuits on non-OK, and evaluates its argument exactly once. */
+void test_conformance_hal_ok_or_return_passes_through(void);
+void test_conformance_hal_ok_or_return_short_circuits(void);
 
 /* Null-pointer contract — every public init function that takes a
- * pointer must reject NULL with HAL_ERR_INVALID_ARG, not crash. */
+ * pointer must reject NULL with HAL_ERR_INVALID_ARG, not crash; and
+ * calling the NULL path twice in a row must return the same status
+ * both times (no state corruption on the error branch). */
 void test_conformance_uart_init_rejects_null(void);
 void test_conformance_clock_init_rejects_null(void);
 void test_conformance_dma_init_rejects_null(void);
@@ -61,6 +66,7 @@ void test_conformance_spi_init_rejects_null(void);
 void test_conformance_pwm_init_rejects_null(void);
 void test_conformance_sdio_init_rejects_null(void);
 void test_conformance_gpio_init_rejects_null(void);
+void test_conformance_null_init_is_idempotent(void);
 
 /* Capability-flag contract — NAVHAL_HAS_X is always 0 or 1, never
  * unset (#ifdef NAVHAL_HAS_X yields a value; the macro is a contract,

--- a/tests/portable/test_crc.c
+++ b/tests/portable/test_crc.c
@@ -120,6 +120,15 @@ void test_hal_crc_compute_mpeg2_reference_vector(void) {
   const uint8_t s[] = {'1', '2', '3', '4', '5', '6', '7', '8', '9'};
   TEST_ASSERT_EQUAL_UINT32(0x0376E6E7u, hal_crc_compute(s, sizeof(s)));
 }
+/* PROGMEM slot for each case name on AVR; no-op elsewhere. */
+NAVTEST_CASE_DECL(test_crc_empty_returns_init);
+NAVTEST_CASE_DECL(test_crc_single_byte);
+NAVTEST_CASE_DECL(test_crc_known_vector);
+NAVTEST_CASE_DECL(test_crc_accumulate_matches_compute);
+NAVTEST_CASE_DECL(test_crc_reset_restores_init);
+NAVTEST_CASE_DECL(test_hal_crc_init_rejects_null_config);
+NAVTEST_CASE_DECL(test_hal_crc_compute_mpeg2_reference_vector);
+
 
 static const navtest_case_t crc_cases[] = {
     NAVTEST_CASE(test_crc_empty_returns_init),

--- a/tests/portable/test_flash_raw.c
+++ b/tests/portable/test_flash_raw.c
@@ -86,6 +86,14 @@ void test_hal_flash_needs_compaction_returns_bool(void) {
 void test_hal_flash_erase_returns_ok(void) {
   TEST_ASSERT_EQUAL_UINT32((uint32_t)HAL_OK, (uint32_t)hal_flash_erase());
 }
+/* PROGMEM slot for each case name on AVR; no-op elsewhere. */
+NAVTEST_CASE_DECL(test_flash_storage_integration);
+NAVTEST_CASE_DECL(test_hal_flash_save_rejects_null_value);
+NAVTEST_CASE_DECL(test_hal_flash_read_rejects_null_pointers);
+NAVTEST_CASE_DECL(test_hal_flash_delete_then_read_returns_error);
+NAVTEST_CASE_DECL(test_hal_flash_needs_compaction_returns_bool);
+NAVTEST_CASE_DECL(test_hal_flash_erase_returns_ok);
+
 
 static const navtest_case_t flash_cases[] = {
     NAVTEST_CASE(test_flash_storage_integration),

--- a/tests/portable/test_timebase.c
+++ b/tests/portable/test_timebase.c
@@ -94,6 +94,16 @@ void test_hal_timebase_returns_uint32(void) {
   (void)u;
   TEST_ASSERT_TRUE(1);
 }
+/* PROGMEM slot for each case name on AVR; no-op elsewhere. */
+NAVTEST_CASE_DECL(test_hal_timebase_init_returns_ok);
+NAVTEST_CASE_DECL(test_hal_timebase_tick_increments);
+NAVTEST_CASE_DECL(test_hal_timebase_get_tick_duration_us_matches_init);
+NAVTEST_CASE_DECL(test_hal_timebase_get_millis_is_monotonic);
+NAVTEST_CASE_DECL(test_hal_timebase_get_micros_is_monotonic);
+NAVTEST_CASE_DECL(test_hal_timebase_get_reload_value_nonzero);
+NAVTEST_CASE_DECL(test_hal_timebase_set_callback_rejects_null);
+NAVTEST_CASE_DECL(test_hal_timebase_returns_uint32);
+
 
 static const navtest_case_t timebase_cases[] = {
     NAVTEST_CASE(test_hal_timebase_init_returns_ok),


### PR DESCRIPTION
## Summary
- **PROGMEM case names on AVR** — `NAVTEST_CASE_DECL(fn)` puts each test-case name in flash; AVR test ELF SRAM drops 1969 → 759 bytes (96.1% → 37.1% full). No-op on non-AVR.
- **Conformance suite +4 portable properties** — `status_fits_uint8` (RPC ABI), `null_init_is_idempotent` (error path doesn't corrupt state), and the `HAL_OK_OR_RETURN` passes-through/short-circuits pair ported from the host SIL suite. Distinct-codes test now walks the full `hal_status_t` enum pairwise.

## Verification
- Host SIL: 24/24 pass
- AVR (simavr PIL): 36/36 pass, SRAM 811 bytes (39.6% full)
- Cortex-M4 (Renode PIL): 143/143 pass

## Test plan
- [x] `tools/run_host_tests.sh`
- [x] `tools/pil/run.sh atmega328p`
- [x] `tools/pil/run.sh nucleo_f401re`
- [ ] CI required checks green