### PR TITLE
docs: mark NavHAL as a trademark (™)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# NavHAL — NAVRobotec Hardware Abstraction Layer
+# NavHAL™ — NAVRobotec Hardware Abstraction Layer
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE.md)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/ragnar-vallhala/NavHAL/ci.yml?branch=main)](https://github.com/ragnar-vallhala/NavHAL/actions)
@@ -13,7 +13,7 @@
 
 ## Overview
 
-**NavHAL** is a hardware abstraction layer (HAL) written in C for embedded
+**NavHAL™** is a hardware abstraction layer (HAL) written in C for embedded
 systems. Its API is architecture-agnostic *by design* — the layered
 arch / vendor / family / board structure and the Kconfig-driven build are
 built to host multiple targets — but the v1 release ships **one implemented
@@ -133,6 +133,8 @@ Apache License 2.0 — see [LICENSE.md](LICENSE.md) for details.
 
 Copyright © 2025 NAVRobotec Pvt Ltd.
 
+NavHAL™ is a trademark of NAVRobotec Pvt Ltd. All rights reserved.
+
 ---
 
 ## Contact
@@ -145,4 +147,4 @@ Website: [https://navrobotec.com](https://navrobotec.com)
 
 ---
 
-Thank you for exploring NavHAL — the future of portable embedded hardware abstraction!
+Thank you for exploring NavHAL™ — the future of portable embedded hardware abstraction!

--- a/mainpage.md
+++ b/mainpage.md
@@ -1,6 +1,6 @@
-@mainpage NavHAL Documentation
+@mainpage NavHAL™ Documentation
 
-**NavHAL** is a hardware abstraction layer for embedded systems, offering a standardized, frozen C interface for GPIO, UART, I²C, SPI, timers, PWM, DMA, flash, CRC, SDIO, FPU and a cycle counter. The public `hal_*` API is at `HAL_API_VERSION 1`.
+**NavHAL™** is a hardware abstraction layer for embedded systems, offering a standardized, frozen C interface for GPIO, UART, I²C, SPI, timers, PWM, DMA, flash, CRC, SDIO, FPU and a cycle counter. The public `hal_*` API is at `HAL_API_VERSION 1`.
 
 The codebase is laid out so adding a new MCU adds directories, not build-system changes — arch / vendor / family / board are explicit Kconfig axes. v1 ships two implemented ports: **STM32F401RE (Cortex-M4)** and **ATmega328P (AVR)**.
 


### PR DESCRIPTION
NAVRobotec has been granted a (temporary) trademark for **NavHAL**.

This adds the ™ symbol to the project name in the prominent branding spots and a trademark notice:

- `README.md` — H1 title, the first bold mention in **Overview**, the closing line, plus a `NavHAL™ is a trademark of NAVRobotec Pvt Ltd.` notice beside the copyright.
- `mainpage.md` — Doxygen front-page title and lead sentence.

Marks the most prominent uses (per trademark convention) rather than every code reference. Docs-only; no source or API changes.