### PR TITLE
fix(pil): make --install-deps install-only so the suite runs once

### DIFF
--- a/tools/pil/run.sh
+++ b/tools/pil/run.sh
@@ -6,7 +6,7 @@
 #
 # Usage:
 #   tools/pil/run.sh <board>                  # build + run
-#   tools/pil/run.sh <board> --install-deps   # apt-install the deps first
+#   tools/pil/run.sh <board> --install-deps   # install this board's deps, then exit
 #   tools/pil/run.sh --list                   # list known boards
 #
 # Adding a new MCU is one new file under tools/pil/boards/<name>.conf
@@ -68,6 +68,13 @@ done
 # Optional dep installation pass (CI uses this; humans typically don't).
 # Two stages: apt for distro-packaged deps, then an optional SETUP_SCRIPT
 # for things that aren't apt-packaged (e.g. Renode).
+#
+# --install-deps is install-ONLY and exits when done: the CI workflow runs
+# it as a separate "Install deps" stage before the "Build + run" stage, so
+# falling through to build+run here would run the suite twice. The second,
+# back-to-back Renode boot races the dotnet child the first run leaves
+# behind and intermittently writes an empty UART log — a spurious CI red.
+# Humans wanting one shot run `--install-deps` once, then the plain form.
 if [ "$INSTALL_DEPS" = "1" ]; then
   if [ -n "${APT_DEPS:-}" ]; then
     echo ">> apt install ($BOARD): $APT_DEPS"
@@ -83,6 +90,8 @@ if [ "$INSTALL_DEPS" = "1" ]; then
     echo ">> running $SETUP_SCRIPT"
     "$SETUP_SCRIPT"
   fi
+  echo ">> deps installed for $BOARD"
+  exit 0
 fi
 
 echo ">> board=$BOARD arch=$ARCH toolchain=$TOOLCHAIN_FILE"


### PR DESCRIPTION
## Problem

`PIL nucleo_f401re` has been **red on every run since the M7/M8 test-reorg landed** (`217eca6`, 2026-05-27) — including `main` itself and every nightly schedule. It blocks the `PIL required` status check, so nothing can merge.

## Root cause

`.github/workflows/renode.yml` calls the PIL driver twice:

```yaml
- name: Install deps
  run: tools/pil/run.sh ${{ matrix.board }} --install-deps   # intended: install only
- name: Build + run PIL
  run: tools/pil/run.sh ${{ matrix.board }}                  # intended: build + run
```

But `run.sh` had **no `exit` after the install block**, so `--install-deps` installed deps *and fell through to build + run the whole suite*. The on-target tests ran **twice, back to back**.

On `nucleo_f401re` the second Renode boot races the `dotnet` child the first run leaves behind (`Terminate orphan process: (dotnet)` in job teardown) and intermittently emits an **empty UART log** → `run_tests.sh` reports `navtest summary not found` → red. Same failing job, both invocations:

| Invocation | Result |
|---|---|
| 1st (`--install-deps` step) | `Total tests run: 139, Total failures: 0` ✅ |
| 2nd (`Build + run` step) | empty UART → `navtest summary not found` ❌ |

`atmega328p`/simavr is lightweight enough not to flake — which is why only the Cortex-M job was failing.

## Fix

`--install-deps` now **exits after installing**, matching the workflow's two-stage intent. The suite runs **exactly once** (in *Build + run*). Bonus: ~halves PIL wall-clock by not building + emulating twice.

No source, API, or test changes.