### PR TITLE
ci: make sample matrix and Renode runner resilient to leftover state

### DIFF
--- a/tools/build_all_samples.sh
+++ b/tools/build_all_samples.sh
@@ -33,7 +33,25 @@ FAIL=0
 FAIL_LIST=""
 BUILD=build-sample-matrix
 
-cleanup() { rm -rf "$BUILD"; }
+# Build from a clean, Kconfig-default .config rather than whatever target a
+# previous local build left in the repo root. A leftover AVR .config (e.g.
+# from an atmega build) points every no-toolchain sample build at avr-gcc,
+# which then chokes on the Cortex-M startup .s files — a false red that only
+# reproduces on the polluted machine, never in clean CI. Stash and restore.
+SAVED_CONFIG=""
+if [ -f .config ]; then
+  SAVED_CONFIG=$(mktemp)
+  mv .config "$SAVED_CONFIG"
+fi
+
+cleanup() {
+  rm -rf "$BUILD"
+  if [ -n "$SAVED_CONFIG" ] && [ -f "$SAVED_CONFIG" ]; then
+    mv -f "$SAVED_CONFIG" .config
+  else
+    rm -f .config
+  fi
+}
 trap cleanup EXIT
 
 for sample in $SAMPLES; do

--- a/tools/renode/run_tests.sh
+++ b/tools/renode/run_tests.sh
@@ -25,11 +25,25 @@ RESC="$REPO_ROOT/tools/renode/navhal_f401re.resc"
 LOGFILE="$(mktemp -t navhal-uart-XXXXXX.log)"
 
 RENODE_PID=""
+RENODE_PGID=""
 WATCHER_PID=""
 TAIL_PID=""
+
+# Stop Renode and the dotnet/mono child it spawns. When we launched it under
+# its own process group (setsid) we signal the whole group, so the child can't
+# be orphaned (a lingering 'dotnet' otherwise survives into CI teardown);
+# otherwise we fall back to signalling just the launcher pid.
+stop_renode() {
+  if [[ -n "$RENODE_PGID" ]]; then
+    kill -TERM -- "-$RENODE_PGID" 2>/dev/null || true
+  elif [[ -n "$RENODE_PID" ]]; then
+    kill -TERM "$RENODE_PID" 2>/dev/null || true
+  fi
+}
+
 cleanup() {
   [[ -n "$WATCHER_PID" ]] && kill "$WATCHER_PID" 2>/dev/null || true
-  [[ -n "$RENODE_PID"  ]] && kill "$RENODE_PID"  2>/dev/null || true
+  stop_renode
   [[ -n "$TAIL_PID"    ]] && kill "$TAIL_PID"    2>/dev/null || true
   rm -f "$LOGFILE"
 }
@@ -56,12 +70,26 @@ TAIL_PID=$!
 # reports its summary. Without that, the `RunFor` budget inside the .resc
 # keeps Renode emulating the firmware's post-main idle loop until the full
 # 3 emulated hours elapse — looking exactly like "Renode hangs at the end."
-renode \
-  --disable-xwt \
-  --hide-log \
-  -e "\$bin = @$ELF; \$logfile = @$LOGFILE; i @$RESC" \
-  >/dev/null 2>&1 &
-RENODE_PID=$!
+# Run Renode in its own process group (setsid) so the cleanup above can reap
+# the whole tree — the launcher plus its dotnet/mono child. setsid ships with
+# util-linux on every CI runner and dev box we target; degrade to a plain
+# background run (launcher-pid signalling only) if it is somehow unavailable.
+if command -v setsid >/dev/null 2>&1; then
+  setsid renode \
+    --disable-xwt \
+    --hide-log \
+    -e "\$bin = @$ELF; \$logfile = @$LOGFILE; i @$RESC" \
+    >/dev/null 2>&1 &
+  RENODE_PID=$!
+  RENODE_PGID=$RENODE_PID   # setsid makes Renode its own process-group leader
+else
+  renode \
+    --disable-xwt \
+    --hide-log \
+    -e "\$bin = @$ELF; \$logfile = @$LOGFILE; i @$RESC" \
+    >/dev/null 2>&1 &
+  RENODE_PID=$!
+fi
 
 # Watcher: poll the UART log for the navtest summary line. When it shows
 # up, give tail a beat to flush the last few lines, then SIGTERM Renode.
@@ -71,7 +99,7 @@ RENODE_PID=$!
   while kill -0 "$RENODE_PID" 2>/dev/null; do
     if grep -q "Total failures:" "$LOGFILE" 2>/dev/null; then
       sleep 0.5
-      kill -TERM "$RENODE_PID" 2>/dev/null || true
+      stop_renode
       break
     fi
     sleep 0.5


### PR DESCRIPTION
Two robustness fixes for the local pre-push hooks and CI runners, both surfaced while debugging the PIL flake (#25). No source/API changes.

## 1. `build_all_samples.sh` — immune to a leftover `.config`

The matrix configures each sample **without a toolchain file**, so it inherits whatever target the repo-root `.config` names. A `.config` left from a local AVR build (`CONFIG_TOOLCHAIN_PREFIX=avr-`) silently points every sample build at `avr-gcc`, which then can't assemble the Cortex-M startup `.s` files:

```
startup.s:41: Error: unknown pseudo-op: `.syntax'
startup.s:55: Error: division by zero      # avr-as reading the // line comment as division
```

This reproduces **only on the polluted machine, never in clean CI** — which is exactly why the pre-push hook started failing locally while "Build all samples" stayed green. (There was never a real divide-by-zero; line 55 is just `.word Reset_Handler`.)

Fix: stash any existing `.config`, build from Kconfig defaults, restore on exit. **Verified: 28/28 samples build with an AVR `.config` present (was 11/28).**

## 2. `run_tests.sh` — no orphaned `dotnet`

Renode spawns a `dotnet`/mono child; signalling only the launcher pid orphaned it (`Terminate orphan process: (dotnet)` in job teardown). Launch Renode under `setsid` (own process group) and signal the whole group on cleanup; falls back to launcher-pid signalling if `setsid` is absent.

The pre-push sample matrix passed locally **without `--no-verify`**, confirming fix #1 restores the hook.