### PR TITLE
docs(roadmap): add M9–M11 milestone pages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,7 @@ Concretely, a new MCU needs:
 7. PIL (Processor-in-the-Loop) integration:
    * Add `tools/pil/boards/<board>.conf` with the toolchain file, build dir, runner script, and apt deps. See `tools/pil/boards/atmega328p.conf` as the minimal example or `nucleo_f401re.conf` as the full one (with `SETUP_SCRIPT=` for non-apt installs like Renode).
    * Pick the emulator and provide a runner under `tools/<emulator>/run_tests.sh` (mirror `tools/simavr/run_tests.sh` — it's <100 lines).
-   * Add the board to the matrix in `.github/workflows/renode.yml`'s `strategy.matrix.board` list. The dispatcher `tools/pil/run.sh <board>` handles everything else.
+   * Add the board to the matrix in `.github/workflows/renode.yml`'s `strategy.matrix.board` list. The dispatcher (`tools/pil/run.sh BOARD`) handles everything else.
 
 ## Licensing of contributions
 

--- a/docs/roadmap/M10-port-as-package.md
+++ b/docs/roadmap/M10-port-as-package.md
@@ -1,0 +1,184 @@
+@page roadmap_m10 M10 — Port as a registry package
+
+# M10 — Port as a registry package
+
+> Status: **planned**
+> Scope: promote "port" to a first-class kind in the Module ABI.
+> Vendors publish their MCU support as `nav` registry packages
+> instead of PRs to the NavHAL monorepo.
+> Predecessor: M9 (driver vtable). A port is only well-defined when
+> the vendor-facing interface is stable.
+> Unlocks: the strategic shift to Arduino-scale. Vendor velocity
+> decouples from the maintainer; the core repo stays small.
+
+## Goal
+
+After M10:
+
+* `nav board install rp2040` fetches a port package from the
+  registry, extracts its `src/arch/`, `src/vendor/`, `include/port/`
+  contents into a sandboxed location, registers its toolchain file
+  and defconfig, and sources its Kconfig fragment.
+* Existing `cmake -B build -DSAMPLE=hal_blink
+  -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/rp2040-toolchain.cmake`
+  flow continues to work.
+* The NavHAL core repo ships **one** reference port (Cortex-M4 /
+  STM32F401RE). Every other port — including the existing AVR /
+  ATmega328P — lives in its own repo, published to the registry,
+  owned by whoever cares enough to maintain it.
+
+## Why now
+
+Once M9 lands, the vendor-facing interface (`hal_<peripheral>_ops_t`)
+is stable. A port is then a well-defined deliverable:
+*"a struct populated with vendor functions plus a CMake toolchain
+file plus a defconfig plus a Kconfig fragment."*
+
+That deliverable shape **is** a package. Continuing to merge every
+vendor's port into the main repo at that point is friction without
+upside — review bandwidth concentrates on you, the repo grows
+forever, and contributors can't iterate on their port without
+gating on your reviews.
+
+This is also where NavHAL's strategic differentiation from Arduino
+becomes real: Arduino's per-core repos are vendor-maintained but
+mostly *unverified*. NavHAL's port packages flow through the
+quarantine worker (`nav publish`) which can build them against the
+conformance harness from M8.4 before marking them safe. **"Verified
+ports" is a defensible market position.**
+
+## What changes
+
+### 10.1 — `port` kind in `navmod.toml`
+
+Extends [Module ABI v1](../MODULE_ABI.md) with a third package kind:
+
+```toml
+[package]
+kind        = "port"
+name        = "rp2040"
+version     = "1.0.0"
+license     = "Apache-2.0"
+maintainers = ["…@raspberrypi.com"]
+
+[abi]
+abi_version     = 1
+hal_api_version = 1
+conformance     = "tier-1"   # NEW; see §10.3
+
+[port]
+arch              = "cortex-m0"
+vendor            = "rpi"
+families          = ["rp2040"]
+boards            = ["pico", "pico_w"]
+toolchain_file    = "cmake/toolchains/arm-none-eabi-rp2040.cmake"
+defconfig         = "cmake/defconfigs/rp2040_pico.defconfig"
+kconfig_fragment  = "Kconfig.rp2040"
+
+# Optional: capabilities the port claims to implement. Used by the
+# registry UI to filter ports without building them.
+[port.caps]
+provides = ["GPIO", "UART", "I2C", "SPI", "TIMER", "PWM", "CLOCK",
+            "INTERRUPT", "FLASH", "DMA", "CYCLE_COUNTER"]
+absent   = ["FPU", "SDIO", "CRC_HW"]
+```
+
+The `[port]` table is new; everything else mirrors the existing
+`module` / `app` shape from the ABI spec.
+
+### 10.2 — `nav board install` flow
+
+```
+nav board install rp2040
+  ↓
+resolve rp2040 in registry (latest stable matching hal_api_version)
+  ↓
+download tarball, verify quarantine-worker signature
+  ↓
+extract under $NAVHAL_BOARDS_DIR/rp2040/   (~/.nav/boards/rp2040/)
+  ↓
+register toolchain file path in nav's config
+  ↓
+nav build ... -DCMAKE_TOOLCHAIN_FILE=$NAVHAL_BOARDS_DIR/rp2040/.../toolchain.cmake
+```
+
+The board files live OUTSIDE the NavHAL source tree. `cmake -B build`
+sources Kconfig fragments from `$NAVHAL_BOARDS_DIR` automatically
+via a new `BOARDS_ROOT` cmake variable.
+
+### 10.3 — Conformance tiers
+
+Not every port supports every cap; not every port has been HIL-tested.
+Three tiers, descending rigour:
+
+| Tier | Means |
+|---|---|
+| **tier-1: conformant**  | Passes the full conformance harness (M8.4) on a real board. HIL CI run weekly by the port's maintainer. The reference / officially-vetted level. |
+| **tier-2: validated**   | Passes the conformance harness in an emulator only (no HIL). Most community ports start here. |
+| **tier-3: experimental**| Builds against `HAL_API_VERSION 1` and runs Cortex-M-style smoke tests. No claim of behaviour parity with the reference port. |
+
+The tier appears in registry listings and in `nav board show <name>`.
+Apps can require a minimum tier:
+
+```toml
+# my-firmware/nav.toml
+[dependencies]
+ports = { rp2040 = { tier = ">= tier-2" } }
+```
+
+### 10.4 — Reference Cortex-M4 port stays in core
+
+The STM32F401RE port stays bundled in NavHAL because it's the
+reference *and* the conformance test ELF needs *something* to run
+against. Every other port — including the AVR port that's currently
+in-tree — migrates to its own repo (`navhal-port-avr`,
+`navhal-port-rp2040`, etc.).
+
+The migration of AVR specifically is the proof-of-concept for the
+whole M10 mechanism: if AVR-as-package works end-to-end, the
+remaining ports are mechanical.
+
+## Cost estimate
+
+* `port` kind in Module ABI + spec write-up: **~3 days**.
+* `nav board install` / `show` / `list` / `remove` commands: **~2 weeks**
+  (need solid UX, registry-API integration, signature verification,
+  rollback on failure).
+* Sandbox/extraction layout + cmake `BOARDS_ROOT` integration: **~1 week**.
+* AVR migration to standalone repo (proof of concept): **~1 week**.
+* Quarantine-worker integration for ports (auto-build against the
+  conformance harness on publish): **~1 week**.
+* Total: **~6–8 weeks** of focused work.
+
+## Exit criteria
+
+* `navhal-port-avr` repo exists, hosted on GitHub, published to the
+  `nav` registry.
+* `nav board install avr` works end-to-end on a clean machine.
+* `cmake -B build -DSAMPLE=hal_blink` after `nav board install avr`
+  produces the same ELF as today's in-tree AVR build.
+* The Module ABI v1 spec gains a `[port]` section, mirror-committed
+  to both repos.
+* The quarantine worker rejects a port that doesn't pass the
+  conformance harness on every supported target triple.
+
+## Open questions
+
+* **Lifecycle of the in-tree AVR port**: do we delete it the day
+  `navhal-port-avr` is published, or keep it as a deprecated
+  fallback for one release cycle? Keeping it is friendlier;
+  deleting it is the honest commitment to the new model.
+* **Versioning across the core ↔ port boundary**: a port pins
+  `hal_api_version = 1`. If the core ships a v1.1 minor that
+  introduces a new optional cap, can old ports still work? (Yes,
+  since the cap is optional. But the registry needs to know the
+  port's exact target HAL version.)
+* **Conformance tier upgrades over time**: a community port might
+  start tier-3 and reach tier-1 after months. Does the registry
+  re-run conformance automatically when a new core ships? (Should.)
+* **Trademark / branding**: "official NavHAL port" — who decides?
+  Probably tier-1 + maintainer sign-off; needs a written policy.
+* **Single-vendor lock-in risk**: if an MCU vendor publishes
+  `navhal-port-x` and then stops maintaining it, can someone else
+  fork? (License is Apache 2.0, so yes; registry needs a
+  "successor" mechanism.)

--- a/docs/roadmap/M11-hal-api-v2.md
+++ b/docs/roadmap/M11-hal-api-v2.md
@@ -1,0 +1,171 @@
+@page roadmap_m11 M11 — HAL_API_VERSION 2
+
+# M11 — HAL_API_VERSION 2
+
+> Status: **planned (deferred)**
+> Scope: bump the public HAL contract to v2, adding subsystem
+> namespaces that v1 didn't anticipate (USB, Ethernet, BLE, AI
+> accelerators, secure-element).
+> Predecessor: M10 (port-as-package). The version bump only makes
+> sense once vendors are publishing ports independently — otherwise
+> you're flipping a flag for two MCUs.
+> Unlocks: ports for higher-end SoCs (STM32H7, ESP32, nRF52 with
+> BLE, etc.) whose value-add is in subsystems v1 can't model.
+
+## Goal
+
+After M11, NavHAL can host ports for MCUs whose primary feature is
+something v1 doesn't have a namespace for. Today a chip with
+hardware USB OTG can only expose it as a vendor extension
+(`hal_stm32_usb_*`) — which means apps that use it aren't portable
+across vendors. v2 standardises the namespace.
+
+## Why now (and why deferred until after M10)
+
+The v1 freeze was the right call for 2025 — surface area was small,
+the discipline of "never break the contract" mattered more than
+shipping new namespaces. Three things change between v1 and the
+shape an Arduino-scale ecosystem needs:
+
+1. **Chips that ship soon will have USB / Ethernet / BLE as
+   first-class peripherals**, not afterthoughts. RP2040 has USB.
+   ESP32 has WiFi+BT. nRF52 has BLE. STM32H7 has Ethernet MAC. A
+   HAL that can't speak those won't host their ports.
+2. **A v1 → v2 boundary needs a clean upgrade story for existing
+   ports.** That's harder while ports are in-tree (every port
+   migrates simultaneously) and easier once they're packages
+   (each port migrates on its own schedule, advertising
+   `hal_api_version = 1` or `hal_api_version = 2` independently).
+3. **The new namespaces should be designed with real ports in
+   hand**, not on speculation. RP2040 and nRF52 ports landing
+   through M10 will surface the actual API needs.
+
+## What changes
+
+### 11.1 — New subsystem namespaces
+
+Candidate v2 additions, in rough priority order:
+
+| Namespace               | Why it's v2-worthy                                                                       |
+|---|---|
+| `hal_usb_*`             | Common on modern MCUs; v1 has zero namespace for it. |
+| `hal_eth_*`             | STM32H7 / RP2040 PIO-eth / ESP32 — too divergent for vendor extensions to stay portable. |
+| `hal_radio_*`           | BLE / 802.15.4 / sub-GHz radios — needs a unified packet-send/receive API. |
+| `hal_secure_*`          | Hardware secure-element / TrustZone / RoT — needed for any product story. |
+| `hal_dsp_*` / `hal_ai_*` | Optional. Cortex-M55 / Helium / NPU support — speculative for v2.0, probably v2.x. |
+| `hal_can_*`             | CAN bus — common in automotive / industrial; v1's bus drivers don't cover it. |
+
+Each follows the same shape as existing v1 namespaces: status-returning
+functions, capability gating (`NAVHAL_HAS_USB`), opt-in via Kconfig,
+mirrored backend interface (M9 vtable per subsystem).
+
+### 11.2 — Version semantics
+
+`HAL_API_VERSION` becomes a struct rather than a single integer:
+
+```c
+#define HAL_API_VERSION_MAJOR 2
+#define HAL_API_VERSION_MINOR 0
+#define HAL_API_VERSION_PATCH 0
+```
+
+A port advertises the version it targets. The cap-contract is
+extended with `NAVHAL_HAS_API_<NAMESPACE>` flags so apps can
+guard against v2-only namespaces:
+
+```c
+#if NAVHAL_HAS_API_USB
+    hal_usb_init(...);
+#endif
+```
+
+Apps continue to work against v1 unchanged. v1 ports can't fulfil
+a v2 cap-requirement — `nav` rejects the install with a clear
+error pointing at the missing namespace.
+
+### 11.3 — Migration path for existing ports
+
+Port packages stay on `hal_api_version = 1` indefinitely if they
+choose. Vendors who want v2 features bump independently:
+
+```toml
+[abi]
+hal_api_version = 2
+```
+
+The core repo ships v2 reference implementations for the new
+namespaces (against the same Cortex-M4 / STM32F4 reference
+target — the F4 supports USB, so the reference port can
+demonstrate the new API).
+
+### 11.4 — Deprecation policy
+
+v1 stays supported. No removals — additive only. The Apache 2.0
+license + the public contract mean we never break working firmware.
+v1.x can continue to land bug-fix releases; v2.0 is for new code.
+
+Deprecation language goes on individual symbols when their v2
+replacement is better, but the v1 symbol stays linkable.
+
+## Alternative considered: stay on v1 forever
+
+The honest alternative is: **don't bump.** Add USB / Ethernet / BLE
+as namespaces inside v1, calling each addition a "v1 minor". This
+preserves the "v1 is the contract" story and avoids the upgrade
+choreography of having two versions live at once.
+
+The case for bumping anyway:
+
+* v1's stability promise was made with a small surface in mind. The
+  new namespaces are large enough that *some* of them will need
+  shape changes once real usage stresses them — and that means
+  breaking changes, which v1 forbids. v2 gives a future-proofed
+  envelope.
+* Vendors publishing port packages need a clear signal "this port
+  speaks v1, this port speaks v2." Otherwise every port has to
+  advertise an exhaustive list of namespaces and apps have to check
+  each one — clumsier than a single version handshake.
+
+Recommendation: **bump.** But also: don't rush. The v1 freeze is
+serving us well; v2 should land only when there's a concrete vendor
+port that needs it and a working draft of the new API has been
+shaken out in their hands.
+
+## Cost estimate
+
+Hard to pin precisely — depends on which namespaces land in v2.0
+vs v2.x. A conservative v2.0 with just `hal_usb_*` + `hal_eth_*`
+and the cross-cutting versioning machinery: **~3 months** of
+focused work. A more ambitious v2.0 with all six candidate
+namespaces: **~6–9 months**.
+
+## Exit criteria
+
+* `HAL_API_VERSION_MAJOR == 2` in the core repo, with at least
+  one v2-only namespace fully implemented on the reference port.
+* A second port (RP2040 or similar) published to the registry as
+  `hal_api_version = 2`, demonstrating the dual-version-coexist
+  property is real.
+* The Module ABI spec has a worked example of an app pinning
+  `hal_api_version = 2` and a port satisfying it.
+* Cap-contract CI runs on both v1 and v2 reference builds and
+  enforces that v1 symbols haven't moved.
+
+## Open questions
+
+* Is `hal_radio_*` even sensible as a portable abstraction? BLE
+  vs 802.15.4 vs LoRa are wildly different protocols; the unified
+  shape may end up being little more than "send this byte array"
+  / "receive callback" — at which point the value is questionable.
+  Spike before committing.
+* Should `hal_usb_*` cover host mode, device mode, or both? Most
+  embedded usage is device mode; host mode adds enormous
+  complexity. v2.0 = device only; host in v2.x.
+* What about platform-as-code things like **device-tree-style
+  pinmuxing**? Zephyr's devicetree model is heavy but proven. v1
+  has the per-board `linker.ld` + manual pin assignment in source.
+  v2 could introduce a manifest-driven pinmux — would significantly
+  simplify board ports. Probably a separate milestone (M12?).
+* Where does the v2 reference test harness live? The conformance
+  harness from M8.4 needs a v2-aware mode that knows which
+  namespaces a port claims to implement.

--- a/docs/roadmap/M9-driver-vtable.md
+++ b/docs/roadmap/M9-driver-vtable.md
@@ -1,0 +1,177 @@
+@page roadmap_m9 M9 — Driver vtable + vendor-backend abstraction
+
+# M9 — Driver vtable + vendor-backend abstraction
+
+> Status: **planned**
+> Scope: introduce a HAL-internal interface between the public
+> `hal_*` API and per-vendor implementations, so adding a new vendor
+> means filling in a vtable, not re-writing every driver from scratch.
+> Predecessor: M7 (modular build) — vtable layout cleanly per arch
+> requires per-arch CMake fragments to install it.
+> Unlocks: ~80 % less per-vendor boilerplate; mechanical conformance
+> enforcement (the vtable shape *is* the contract).
+
+## Goal
+
+After M9, a new vendor adds:
+
+* One file per driver: `src/vendor/<vendor>/<peripheral>/<peripheral>.c`,
+  filling in the vendor-specific operations.
+* No new public headers. No new types. No copies of validation logic.
+* A single declaration like `NAVHAL_REGISTER_VENDOR(nrf52, &nrf52_ops);`
+  in a port-init file.
+
+The public `hal_gpio_init(pin, cfg)` call goes through the same code
+path on every vendor — it validates `cfg`, then dispatches to the
+vendor's `gpio_init_impl(pin, cfg)` via the vtable.
+
+## Why now
+
+The current model is **vendor = copy and re-implement**. Today's `gpio.c`
+files:
+
+```
+src/vendor/stm32/gpio/gpio.c        ~400 lines
+src/vendor/microchip/gpio/gpio.c    ~200 lines
+```
+
+Both implement the same `hal_status_t hal_gpio_init(...)` API. Both
+validate the same `cfg` field combinations (`HAL_GPIO_MODE_AF` requires
+a non-zero `alternate`, etc.). Both translate `HAL_GPIO_PULL_UP` to
+vendor-specific registers.
+
+Add five more vendors and you've got seven copies of the same
+validation, plus seven chances to silently disagree on edge cases.
+The cap-contract checks "does the symbol exist", not "does it implement
+the same semantics" — and the more vendors, the more likely a port
+ships with a subtly different behaviour from the reference one.
+
+## What changes
+
+### 9.1 — Vtable shape per driver
+
+A vendor-facing interface per HAL subsystem. Example for GPIO:
+
+```c
+/* include/internal/hal_gpio_ops.h — NOT public */
+typedef struct {
+    hal_status_t (*init)        (hal_gpio_pin_t pin, const hal_gpio_config_t *cfg);
+    hal_status_t (*set_mode)    (hal_gpio_pin_t pin, hal_gpio_mode_t mode,
+                                 hal_gpio_pull_t pull);
+    hal_gpio_mode_t (*get_mode) (hal_gpio_pin_t pin);
+    /* …one entry per public hal_gpio_* function… */
+} hal_gpio_ops_t;
+
+extern const hal_gpio_ops_t *const _hal_gpio_ops;   /* set by the port */
+```
+
+`include/common/hal_gpio.c` (new!) provides the public implementation,
+which validates and dispatches:
+
+```c
+hal_status_t hal_gpio_init(hal_gpio_pin_t pin, const hal_gpio_config_t *cfg) {
+    if (!cfg) return HAL_ERR_INVALID_ARG;
+    if (cfg->mode == HAL_GPIO_MODE_AF && cfg->alternate == HAL_GPIO_AF_NONE)
+        return HAL_ERR_INVALID_ARG;
+    return _hal_gpio_ops->init(pin, cfg);
+}
+```
+
+Vendor `src/vendor/stm32/gpio/gpio.c` becomes:
+
+```c
+static hal_status_t stm32_gpio_init_impl(hal_gpio_pin_t pin, const hal_gpio_config_t *cfg) {
+    /* register-poking only — validation already happened upstream */
+    ...
+}
+
+static const hal_gpio_ops_t stm32_gpio_ops = {
+    .init     = stm32_gpio_init_impl,
+    .set_mode = stm32_gpio_set_mode_impl,
+    /* … */
+};
+
+const hal_gpio_ops_t *const _hal_gpio_ops = &stm32_gpio_ops;
+```
+
+### 9.2 — Per-subsystem migration
+
+Roll this out one subsystem at a time so each step is reviewable:
+
+| Order | Subsystem      | Why this order |
+|---|---|---|
+| 1 | GPIO           | Smallest stable surface, most heavily duplicated, lowest risk |
+| 2 | UART           | Second-smallest surface; sets the pattern for "options struct" |
+| 3 | INTERRUPT      | Architecture-touching but the pattern is similar |
+| 4 | TIMER + PWM    | Closely related, do them together |
+| 5 | I2C + SPI      | Both are bus drivers with similar shape |
+| 6 | DMA            | Capability-gated — only ports with `NAVHAL_HAS_DMA == 1` need the ops table |
+| 7 | FLASH          | Touches hardware-write semantics; do last |
+| 8 | CLOCK          | The chicken-and-egg one — drivers may depend on it; resolve after |
+
+Each subsystem migration is one PR. Cap-contract test gates the
+behaviour-preservation property.
+
+### 9.3 — Cost-of-abstraction defence
+
+The vtable adds one indirect call per HAL invocation. On Cortex-M
+that's ~3 cycles; on AVR with ~16 MHz it's measurable on tight
+loops. Mitigation:
+
+* For known hot paths (GPIO `set` / `clear` / `toggle`), keep the
+  inline accessors in the port header (today's pattern). The vtable
+  covers the slow-path init/config calls. AVR's "inline GPIO" perf
+  commit (ecae042) stays correct.
+* `-flto` on release builds devirtualises the indirect call when the
+  ops table is `const` and known at link time. Common pattern in
+  Zephyr's device-driver model.
+
+### 9.4 — Conformance enforcement
+
+Once the vtable is the contract, a port that doesn't fill in an
+entry can be caught at build time (`-Wmissing-field-initializers`)
+or at link time (the symbol stays NULL). The conformance test from
+M8.4 walks every required vtable entry and asserts non-NULL plus
+documented-behaviour. This becomes the "did the port really
+implement the HAL" gate that's missing today.
+
+## Cost estimate
+
+* Subsystem 1 (GPIO): **~1 week**. Most of the design effort lives
+  here — what does an ops table look like, how does validation split
+  between public layer and vendor layer, how do the inline hot-paths
+  survive.
+* Subsystems 2–8: **~3 days each**, mostly mechanical once GPIO sets
+  the pattern. Call it **~5 weeks** total for the migration.
+* Conformance harness: ~1 week.
+* Total: **~6–7 weeks** of focused work, end to end.
+
+## Exit criteria
+
+* Adding a hypothetical "RP2040 GPIO" port = filling in
+  `rp2040_gpio_ops`, no other code changes. Concrete proof: a
+  one-PR addition of a new vendor's GPIO that's ≤ 300 lines.
+* Conformance harness covers every public `hal_*` function and
+  documents the expected behaviour. Passes on both Cortex-M4 and AVR.
+* No vendor `gpio.c` (or other migrated subsystem) re-implements
+  validation logic that's already in the public layer.
+* Performance: AVR `hal_gpio_set` is ≤ 2 cycles slower than today's
+  inlined version; release builds with `-flto` show no regression.
+
+## Open questions
+
+* Should the vtable be a `const struct` at fixed address (Zephyr's
+  pattern, devirtualises under LTO) or function-pointer-via-getter
+  (more flexible, slower)? Probably the former — embedded targets
+  prize the perf.
+* What about subsystems where vendor implementations are *wildly*
+  different — e.g., a chip with hardware multi-master I²C arbitration
+  that needs APIs the rest don't have? Two options: extend the ops
+  table with optional entries (caller checks for non-NULL), or
+  punt to a vendor-specific extension namespace
+  (`hal_stm32_i2c_*`). M9 needs an answer before the I²C migration.
+* When a port wants to substitute an arch-shared implementation
+  (e.g., a software-emulated SPI on a chip without hardware SPI),
+  how does the vtable accommodate? Probably: software-fallback
+  vendor `software_spi_ops` lives in `src/vendor/_software/`, ports
+  point at it when their hardware is missing.


### PR DESCRIPTION
Adds the remaining roadmap milestone pages and a small CONTRIBUTING fix.

## What

- **`docs/roadmap/M9-driver-vtable.md`** — M9: driver vtable / vendor-backend abstraction.
- **`docs/roadmap/M10-port-as-package.md`** — M10: port as a registry package.
- **`docs/roadmap/M11-hal-api-v2.md`** — M11: `HAL_API_VERSION 2`.
- **`CONTRIBUTING.md`** — escape `<board>` → `BOARD` in the PIL dispatcher example so Markdown renderers do not swallow it as an HTML tag.

Each milestone page carries the standard status / scope / predecessor / unlocks block matching the existing M7/M8 pages, and slots into the `@ref`-linked table in the roadmap README.

## Notes

Docs-only; no code or build changes. The M9–M11 pages were already `@ref`-linked from the roadmap README table — this fills in the target pages.