### PR TITLE
build(modular): per-port Kconfig fragments (M7 §7.2)

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1,6 +1,17 @@
 # vim: ft=kconfig
 mainmenu "NavHAL Configuration System"
 
+# Platform selection (arch / vendor / family / board) is contributed by
+# per-port Kconfig fragments under each port's own source tree (M7 §7.2),
+# glob-sourced below. Adding an MCU is purely additive: drop the fragment
+# files into src/arch, src/vendor, src/board — no edits to this file.
+#
+# Each choice sources the ports' "Kconfig.choice" members. Their
+# mutual-exclusion default falls out of the `depends on` chain
+# (arch ▶ vendor ▶ family ▶ board): exactly one member is visible per
+# parent selection, and a choice auto-selects its single visible member,
+# so no per-port "default X if PARENT" lines are needed here.
+
 menu "Target Platform Configuration"
 
 choice
@@ -8,144 +19,53 @@ choice
     default ARCH_CORTEX_M4
     help
       Select the target processor architecture.
-
-config ARCH_CORTEX_M4
-    bool "Cortex-M4"
-
-config ARCH_AVR8
-    bool "AVR8 (8-bit)"
-    help
-      8-bit AVR architecture (ATmega / ATtiny). Implemented by the M6
-      port; arch sources live under src/arch/avr/.
-
+source "src/arch/*/Kconfig.choice"
 endchoice
-
-config CMAKE_SYSTEM_PROCESSOR
-    string
-    default "cortex-m4" if ARCH_CORTEX_M4
-    default "avr"       if ARCH_AVR8
-
-# Source-tree slug for the ISA / arch layer (src/arch/<ARCH_ISA>/).
-# A single ISA covers multiple processors (Cortex-M3/M4/M7 all share
-# armv7e-m startup, NVIC, SysTick), so this is a distinct axis from
-# CMAKE_SYSTEM_PROCESSOR which names a specific core.
-config ARCH_ISA
-    string
-    default "armv7e-m" if ARCH_CORTEX_M4
-    default "avr"      if ARCH_AVR8
 
 choice
     prompt "Vendor"
-    default VENDOR_STM32     if ARCH_CORTEX_M4
-    default VENDOR_MICROCHIP if ARCH_AVR8
     help
       Select the silicon vendor.
-
-config VENDOR_STM32
-    bool "STM32"
-    depends on ARCH_CORTEX_M4
-
-config VENDOR_MICROCHIP
-    bool "Microchip"
-    depends on ARCH_AVR8
-    help
-      Microchip (formerly Atmel) AVR silicon.
-
+source "src/vendor/*/Kconfig.choice"
 endchoice
-
-config VENDOR
-    string
-    default "stm32"     if VENDOR_STM32
-    default "microchip" if VENDOR_MICROCHIP
 
 choice
     prompt "Vendor Device Family"
-    default FAMILY_STM32F4     if VENDOR_STM32
-    default FAMILY_ATMEGA328P  if VENDOR_MICROCHIP
     help
       Select the device family within the selected vendor. This is the
       register-layout axis: a single vendor can ship multiple families
       with different register maps (STM32F4 vs STM32F0 vs ...).
-
-config FAMILY_STM32F4
-    bool "STM32F4 (Cortex-M4)"
-    depends on VENDOR_STM32
-
-config FAMILY_ATMEGA328P
-    bool "ATmega328P"
-    depends on VENDOR_MICROCHIP
-
+source "src/vendor/*/family/*/Kconfig.choice"
 endchoice
-
-config FAMILY
-    string
-    default "stm32f4"     if FAMILY_STM32F4
-    default "atmega328p"  if FAMILY_ATMEGA328P
 
 choice
     prompt "Target Board"
-    default BOARD_NUCLEO_F401RE if FAMILY_STM32F4
-    default BOARD_ATMEGA328P    if FAMILY_ATMEGA328P
     help
       Select the target development board.
-
-config BOARD_NUCLEO_F401RE
-    bool "nucleo_f401re"
-    depends on FAMILY_STM32F4
-
-config BOARD_ATMEGA328P
-    bool "atmega328p"
-    depends on FAMILY_ATMEGA328P
-
+source "src/board/*/Kconfig.choice"
 endchoice
 
-config BOARD
-    string
-    default "nucleo_f401re" if BOARD_NUCLEO_F401RE
-    default "atmega328p"    if BOARD_ATMEGA328P
+# Per-port identity strings (ARCH_ISA / VENDOR / FAMILY / BOARD /
+# CMAKE_SYSTEM_PROCESSOR) and per-arch build defaults.
+source "src/arch/*/Kconfig"
+source "src/vendor/*/Kconfig"
+source "src/vendor/*/family/*/Kconfig"
+source "src/board/*/Kconfig"
 
 endmenu
 
 menu "System & Features Configuration"
 
-# DMA, the hardware FPU and the DWT cycle counter are Cortex-M
-# peripherals with no ATmega328P equivalent — gated to ARCH_CORTEX_M4
-# so they cannot be selected on AVR.
-
-config USE_FPU
-    bool "Enable Hardware FPU Compiler Flags"
-    depends on ARCH_CORTEX_M4
-    default n
-    help
-      Enable hardware Floating Point Unit compiler and linker flags.
-
-config DRV_DMA
-    bool "Enable Direct Memory Access (DMA)"
-    depends on ARCH_CORTEX_M4
-    default n
-    select DRV_INTERRUPT
-    help
-      Enables support for the DMA hardware controller.
+# Arch-specific peripheral toggles (FPU, DMA, DWT, ...) ship with their
+# arch under src/arch/<isa>/Kconfig.features. osource: not every arch has
+# arch-specific features.
+osource "src/arch/*/Kconfig.features"
 
 config DRV_CRC
     bool "Enable Hardware CRC Unit"
     default n
     help
       Enables hardware cyclic redundancy check unit support.
-
-config DRV_DWT
-    bool "Enable Debug Watchpoint and Trace (DWT)"
-    depends on ARCH_CORTEX_M4
-    default n
-    help
-      Enables the DWT counter for high-resolution timing.
-
-config DRV_FPU
-    bool "Enable FPU Driver Extension"
-    depends on ARCH_CORTEX_M4
-    default n
-    help
-      Enables compilation of hardware FPU runtime setup files.
 
 endmenu
 
@@ -242,10 +162,11 @@ endmenu
 
 menu "Build Options"
 
+# Per-arch toolchain identity: the prompt lives here (shared, overridable
+# in menuconfig); each arch contributes its "default ... if ARCH_*" under
+# src/arch/<isa>/Kconfig.
 config TOOLCHAIN_PREFIX
     string "Toolchain Binary Prefix"
-    default "arm-none-eabi-" if ARCH_CORTEX_M4
-    default "avr-"           if ARCH_AVR8
     help
       Prefix for the toolchain binaries (e.g. arm-none-eabi-, avr-).
 
@@ -264,12 +185,8 @@ config TEST
 
 config FLASHER
     string "Binary Flasher Tool"
-    default "st-flash" if ARCH_CORTEX_M4
-    default "avrdude"  if ARCH_AVR8
 
 config FLASH_ADDRESS
     string "Flash Target Address"
-    default "0x8000000" if ARCH_CORTEX_M4
-    default "0x0"       if ARCH_AVR8
 
 endmenu

--- a/docs/roadmap/M7-modular-build.md
+++ b/docs/roadmap/M7-modular-build.md
@@ -2,8 +2,8 @@
 
 # M7 — Modular build system
 
-> Status: **partial** — §7.1 (CMake fragments) and §7.3 (sample Kconfig)
-> landed; §7.2 (per-port Kconfig fragments) deferred. See "What landed"
+> Status: **done** — §7.1 (CMake fragments), §7.2 (per-port Kconfig
+> fragments) and §7.3 (sample Kconfig) all landed. See "What landed"
 > at the bottom.
 > Scope: split monolithic `CMakeLists.txt` + `Kconfig` into per-port fragments.
 > Predecessor: M6 (AVR port). No external dependencies.
@@ -127,25 +127,72 @@ runs unchanged.
 ## What landed (M7 v1)
 
 §7.1 (CMake) and §7.3 (sample Kconfig) shipped — the high-leverage
-work. §7.2 (per-port Kconfig fragments for arch / vendor / family /
-board choices) was deferred because:
+work. §7.2 (per-port Kconfig fragments) was initially deferred over
+one concern:
 
-* The choice blocks in root Kconfig have interdependent defaults
-  (`default FAMILY_STM32F4 if VENDOR_STM32`) that don't cleanly factor
-  into per-port files without each port knowing about every other
-  port's choices.
-* Per-port fragments are most valuable when there are many ports
-  pulling at the schema — at two MCUs the root Kconfig is still
-  readable.
+* The choice blocks in root Kconfig appeared to have interdependent
+  defaults (`default FAMILY_STM32F4 if VENDOR_STM32`) that didn't
+  cleanly factor into per-port files without each port knowing about
+  every other port's choices.
 
-§7.2 picks back up under **M7 v2** when either:
-1. A third MCU is being added and the choice-block clutter
-   actually starts to hurt review, or
-2. M10 (port-as-package) is in progress and ports need to ship
-   their Kconfig fragment in their own repo.
+## What landed (M7 v2 — §7.2)
 
-Until then, the M7 v1 wins:
-* Adding an arch is one new `cmake/arch/<ARCH_ISA>.cmake` file —
-  no edits to root `CMakeLists.txt`.
+§7.2 shipped, and the "interdependent defaults" blocker dissolved on
+closer inspection: **those conditional defaults are redundant with the
+`depends on` chain.** Each vendor `depends on` its arch, each family on
+its vendor, each board on its family. So under any parent selection
+exactly one child member is *visible*, and a Kconfig `choice`
+auto-selects its single visible member — the `default X if PARENT`
+lines never actually decided anything. Dropping them removes the
+cross-port coupling entirely.
+
+Mechanism:
+
+* Each port axis owns fragments under its own source tree:
+  * `src/arch/<isa>/Kconfig.choice` — the arch's entry in the
+    "Processor Architecture" choice; `…/Kconfig` — its identity
+    strings (`ARCH_ISA`, `CMAKE_SYSTEM_PROCESSOR`) and per-arch build
+    defaults (toolchain prefix, flasher, flash address);
+    `…/Kconfig.features` — arch-only peripheral toggles (FPU, DMA,
+    DWT — Cortex-M only).
+  * `src/vendor/<vendor>/Kconfig{,.choice}` and
+    `src/vendor/<vendor>/family/<family>/Kconfig{,.choice}` —
+    vendor / family choice entries and their `VENDOR` / `FAMILY`
+    identity strings.
+  * `src/board/<board>/Kconfig{,.choice}` — board choice entry and
+    its `BOARD` identity string.
+* The root `Kconfig` glob-sources these: each `choice` block does
+  `source "src/.../Kconfig.choice"` (kconfiglib supports `source`
+  inside a choice and glob patterns), and the identity/feature
+  fragments are sourced outside the choices. The prompted build knobs
+  (`TOOLCHAIN_PREFIX` etc.) keep their single prompt in root; each arch
+  only contributes a `default … if ARCH_*`.
+
+Verification (all four target × sample combinations):
+
+* `tools/kconfig.py` produces the **identical** symbol set and values
+  (`.config`, `config.cmake`, `autoconf.h`, `navhal_target.h`) before
+  and after — the only delta is emission order, which is irrelevant to
+  object-like `#define`s and `set(... CACHE)` lines.
+* `hal_blink` links to a **byte-identical ELF** on both arches
+  (Cortex-M4 and AVR) when built from the same path.
+* Dropping a throwaway `src/arch/rv32/Kconfig.choice` makes `ARCH_RV32`
+  appear in the arch choice with **zero edits to root `Kconfig`** —
+  the "purely additive" goal.
+
+Note on the original `< 50 lines` exit target: it conflicted with the
+same section's "common driver caps stay here," and the latter wins. The
+*platform-selection ladder* (arch / vendor / family / board, ~90 lines)
+is fully externalized and no per-port option remains in root; the
+common driver / feature / build menus legitimately stay inline, so the
+root is ~190 lines. The scaling pain the milestone targeted — the
+per-port choice ladder — is gone.
+
+The M7 wins:
+* Adding an arch is one new `cmake/arch/<ARCH_ISA>.cmake` file plus a
+  fragment under `src/arch/<isa>/` — no edits to root `CMakeLists.txt`
+  or root `Kconfig`.
+* Adding a vendor / family / board is a fragment under its source
+  tree — no edits to root `Kconfig`.
 * Adding a sample is one edit to `samples/Kconfig` — no edits to
   root `Kconfig`.

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -38,7 +38,7 @@ This roadmap is the work to get there, factored into five milestones.
 
 | Milestone        | Status      | Scope                                       | Unlocks                                              |
 |---|---|---|---|
-| @ref roadmap_m7  | partial — v1 done, v2 deferred | Modular build system | 5–15 MCUs without CMakeLists/Kconfig becoming a swamp |
+| @ref roadmap_m7  | **done**    | Modular build system | 5–15 MCUs without CMakeLists/Kconfig becoming a swamp |
 | @ref roadmap_m8  | **done**    | CI tiering + portable test framework        | Per-arch CI scaling; HAL-only tests run on every arch |
 | @ref roadmap_m9  | planned     | Driver vtable / vendor-backend abstraction  | ~80 % less per-vendor boilerplate; conformance enforced by interface |
 | @ref roadmap_m10 | planned     | Port as a registry package                  | Strategic shift away from monorepo. Vendors publish ports independently. |

--- a/src/arch/armv7e-m/Kconfig
+++ b/src/arch/armv7e-m/Kconfig
@@ -1,0 +1,29 @@
+# vim: ft=kconfig
+# Per-arch identity + build defaults for the armv7e-m ISA (M7 §7.2).
+# Sourced unconditionally at top level. Every "default ... if ARCH_*"
+# is gated on this arch's choice symbol, so only the selected arch
+# contributes a value. Several arches defining the same string symbol
+# is intentional — kconfiglib merges the defaults; the prompted build
+# knobs (TOOLCHAIN_PREFIX / FLASHER / FLASH_ADDRESS) are declared once
+# in the root and only have their per-arch default added here.
+
+# CMAKE_SYSTEM_PROCESSOR names a specific core; ARCH_ISA is the
+# source-tree slug for the ISA layer (src/arch/<ARCH_ISA>/). A single
+# ISA covers multiple processors (Cortex-M3/M4/M7 share armv7e-m
+# startup, NVIC, SysTick), so the two are distinct axes.
+config CMAKE_SYSTEM_PROCESSOR
+    string
+    default "cortex-m4" if ARCH_CORTEX_M4
+
+config ARCH_ISA
+    string
+    default "armv7e-m" if ARCH_CORTEX_M4
+
+config TOOLCHAIN_PREFIX
+    default "arm-none-eabi-" if ARCH_CORTEX_M4
+
+config FLASHER
+    default "st-flash" if ARCH_CORTEX_M4
+
+config FLASH_ADDRESS
+    default "0x8000000" if ARCH_CORTEX_M4

--- a/src/arch/armv7e-m/Kconfig.choice
+++ b/src/arch/armv7e-m/Kconfig.choice
@@ -1,0 +1,6 @@
+# vim: ft=kconfig
+# Processor Architecture choice entry for the armv7e-m ISA (M7 §7.2).
+# Sourced inside the root "Processor Architecture" choice.
+
+config ARCH_CORTEX_M4
+    bool "Cortex-M4"

--- a/src/arch/armv7e-m/Kconfig.features
+++ b/src/arch/armv7e-m/Kconfig.features
@@ -1,0 +1,37 @@
+# vim: ft=kconfig
+# Arch-specific peripheral toggles for the armv7e-m ISA (M7 §7.2).
+# Sourced inside the root "System & Features Configuration" menu.
+#
+# DMA, the hardware FPU, the DWT cycle counter and the FPU runtime are
+# Cortex-M peripherals with no ATmega328P equivalent, so they live with
+# the arch rather than in the common root. (AVR ships no Kconfig.features
+# fragment — there is nothing arch-specific to toggle there yet.)
+
+config USE_FPU
+    bool "Enable Hardware FPU Compiler Flags"
+    depends on ARCH_CORTEX_M4
+    default n
+    help
+      Enable hardware Floating Point Unit compiler and linker flags.
+
+config DRV_DMA
+    bool "Enable Direct Memory Access (DMA)"
+    depends on ARCH_CORTEX_M4
+    default n
+    select DRV_INTERRUPT
+    help
+      Enables support for the DMA hardware controller.
+
+config DRV_DWT
+    bool "Enable Debug Watchpoint and Trace (DWT)"
+    depends on ARCH_CORTEX_M4
+    default n
+    help
+      Enables the DWT counter for high-resolution timing.
+
+config DRV_FPU
+    bool "Enable FPU Driver Extension"
+    depends on ARCH_CORTEX_M4
+    default n
+    help
+      Enables compilation of hardware FPU runtime setup files.

--- a/src/arch/avr/Kconfig
+++ b/src/arch/avr/Kconfig
@@ -1,0 +1,21 @@
+# vim: ft=kconfig
+# Per-arch identity + build defaults for the AVR8 ISA (M7 §7.2).
+# See src/arch/armv7e-m/Kconfig for the conventions; the prompted build
+# knobs are declared in the root and only get their per-arch default here.
+
+config CMAKE_SYSTEM_PROCESSOR
+    string
+    default "avr" if ARCH_AVR8
+
+config ARCH_ISA
+    string
+    default "avr" if ARCH_AVR8
+
+config TOOLCHAIN_PREFIX
+    default "avr-" if ARCH_AVR8
+
+config FLASHER
+    default "avrdude" if ARCH_AVR8
+
+config FLASH_ADDRESS
+    default "0x0" if ARCH_AVR8

--- a/src/arch/avr/Kconfig.choice
+++ b/src/arch/avr/Kconfig.choice
@@ -1,0 +1,9 @@
+# vim: ft=kconfig
+# Processor Architecture choice entry for the AVR8 ISA (M7 §7.2).
+# Sourced inside the root "Processor Architecture" choice.
+
+config ARCH_AVR8
+    bool "AVR8 (8-bit)"
+    help
+      8-bit AVR architecture (ATmega / ATtiny). Implemented by the M6
+      port; arch sources live under src/arch/avr/.

--- a/src/board/atmega328p/Kconfig
+++ b/src/board/atmega328p/Kconfig
@@ -1,0 +1,7 @@
+# vim: ft=kconfig
+# Board identity string for the bare ATmega328P board (M7 §7.2).
+# Sourced at top level.
+
+config BOARD
+    string
+    default "atmega328p" if BOARD_ATMEGA328P

--- a/src/board/atmega328p/Kconfig.choice
+++ b/src/board/atmega328p/Kconfig.choice
@@ -1,0 +1,8 @@
+# vim: ft=kconfig
+# Target-board choice entry for the bare ATmega328P board (M7 §7.2).
+# Sourced inside the root "Target Board" choice. Visible only when its
+# family is selected, so it auto-selects then.
+
+config BOARD_ATMEGA328P
+    bool "atmega328p"
+    depends on FAMILY_ATMEGA328P

--- a/src/board/nucleo_f401re/Kconfig
+++ b/src/board/nucleo_f401re/Kconfig
@@ -1,0 +1,6 @@
+# vim: ft=kconfig
+# Board identity string for Nucleo-F401RE (M7 §7.2). Sourced at top level.
+
+config BOARD
+    string
+    default "nucleo_f401re" if BOARD_NUCLEO_F401RE

--- a/src/board/nucleo_f401re/Kconfig.choice
+++ b/src/board/nucleo_f401re/Kconfig.choice
@@ -1,0 +1,8 @@
+# vim: ft=kconfig
+# Target-board choice entry for Nucleo-F401RE (M7 §7.2).
+# Sourced inside the root "Target Board" choice. Visible only when its
+# family is selected, so it auto-selects then.
+
+config BOARD_NUCLEO_F401RE
+    bool "nucleo_f401re"
+    depends on FAMILY_STM32F4

--- a/src/vendor/microchip/Kconfig
+++ b/src/vendor/microchip/Kconfig
@@ -1,0 +1,6 @@
+# vim: ft=kconfig
+# Vendor identity string for Microchip (M7 §7.2). Sourced at top level.
+
+config VENDOR
+    string
+    default "microchip" if VENDOR_MICROCHIP

--- a/src/vendor/microchip/Kconfig.choice
+++ b/src/vendor/microchip/Kconfig.choice
@@ -1,0 +1,11 @@
+# vim: ft=kconfig
+# Vendor choice entry for Microchip (M7 §7.2).
+# Sourced inside the root "Vendor" choice. Visible only on AVR8, so it
+# auto-selects when that arch is active — no explicit choice default
+# needed.
+
+config VENDOR_MICROCHIP
+    bool "Microchip"
+    depends on ARCH_AVR8
+    help
+      Microchip (formerly Atmel) AVR silicon.

--- a/src/vendor/microchip/family/atmega328p/Kconfig
+++ b/src/vendor/microchip/family/atmega328p/Kconfig
@@ -1,0 +1,6 @@
+# vim: ft=kconfig
+# Family identity string for ATmega328P (M7 §7.2). Sourced at top level.
+
+config FAMILY
+    string
+    default "atmega328p" if FAMILY_ATMEGA328P

--- a/src/vendor/microchip/family/atmega328p/Kconfig.choice
+++ b/src/vendor/microchip/family/atmega328p/Kconfig.choice
@@ -1,0 +1,8 @@
+# vim: ft=kconfig
+# Device-family choice entry for ATmega328P (M7 §7.2).
+# Sourced inside the root "Vendor Device Family" choice. Visible only
+# when its vendor is selected, so it auto-selects then.
+
+config FAMILY_ATMEGA328P
+    bool "ATmega328P"
+    depends on VENDOR_MICROCHIP

--- a/src/vendor/stm32/Kconfig
+++ b/src/vendor/stm32/Kconfig
@@ -1,0 +1,6 @@
+# vim: ft=kconfig
+# Vendor identity string for STM32 (M7 §7.2). Sourced at top level.
+
+config VENDOR
+    string
+    default "stm32" if VENDOR_STM32

--- a/src/vendor/stm32/Kconfig.choice
+++ b/src/vendor/stm32/Kconfig.choice
@@ -1,0 +1,9 @@
+# vim: ft=kconfig
+# Vendor choice entry for STM32 (M7 §7.2).
+# Sourced inside the root "Vendor" choice. Visible only on Cortex-M4,
+# so it auto-selects when that arch is active — no explicit choice
+# default needed.
+
+config VENDOR_STM32
+    bool "STM32"
+    depends on ARCH_CORTEX_M4

--- a/src/vendor/stm32/family/stm32f4/Kconfig
+++ b/src/vendor/stm32/family/stm32f4/Kconfig
@@ -1,0 +1,6 @@
+# vim: ft=kconfig
+# Family identity string for STM32F4 (M7 §7.2). Sourced at top level.
+
+config FAMILY
+    string
+    default "stm32f4" if FAMILY_STM32F4

--- a/src/vendor/stm32/family/stm32f4/Kconfig.choice
+++ b/src/vendor/stm32/family/stm32f4/Kconfig.choice
@@ -1,0 +1,8 @@
+# vim: ft=kconfig
+# Device-family choice entry for STM32F4 (M7 §7.2).
+# Sourced inside the root "Vendor Device Family" choice. Visible only
+# when its vendor is selected, so it auto-selects then.
+
+config FAMILY_STM32F4
+    bool "STM32F4 (Cortex-M4)"
+    depends on VENDOR_STM32


### PR DESCRIPTION
Completes **M7 §7.2** — the last open piece of the Modular Build milestone.

## What

Splits the platform-selection ladder (arch / vendor / family / board) out of the root `Kconfig` into per-port fragments under each port's own source tree, glob-sourced from the root. Adding an MCU is now **purely additive** — drop the fragment files, no edits to the root `Kconfig`.

Each port axis owns:
- `Kconfig.choice` — its member in the relevant `choice` (kconfiglib supports `source` + globs inside a choice);
- `Kconfig` — its identity strings and any per-arch build defaults;
- `armv7e-m` also ships `Kconfig.features` for Cortex-M-only toggles (FPU, DMA, DWT).

## The deferred-blocker, resolved

§7.2 was deferred over "interdependent defaults" (`default FAMILY_X if VENDOR_Y`). Those turned out to be **redundant with the `depends on` chain**: exactly one child is visible per parent selection, and a `choice` auto-selects its single visible member — so the conditional defaults never decided anything. Dropping them removes the cross-port coupling entirely.

## Verification

- Resolved symbol set/values (`.config`, `config.cmake`, `autoconf.h`, `navhal_target.h`) are **unchanged** for both targets — only emission order differs (irrelevant to `#define`s / `set(... CACHE)`).
- `hal_blink` links to a **byte-identical ELF** on Cortex-M4 and AVR.
- Dropping a throwaway `src/arch/rv32/` fragment registers a new arch with **zero root-`Kconfig` edits** — the milestone goal.

Docs: flips M7 to **done** on its milestone page and the roadmap README table, with the §7.2 write-up.