### PR TITLE
feat(gpio): introduce driver vtable dispatch layer (M9)

### DIFF
--- a/docs/roadmap/M9-driver-vtable.md
+++ b/docs/roadmap/M9-driver-vtable.md
@@ -62,36 +62,41 @@ typedef struct {
     /* …one entry per public hal_gpio_* function… */
 } hal_gpio_ops_t;
 
-extern const hal_gpio_ops_t *const _hal_gpio_ops;   /* set by the port */
+/* Embedded directly (a const object, NOT a pointer-to-table) — drops one
+ * indirection and lets -flto devirtualise the dispatch. Defined by the
+ * active vendor. */
+extern const hal_gpio_ops_t _hal_gpio_ops;
 ```
 
-`include/common/hal_gpio.c` (new!) provides the public implementation,
+`src/common/hal_gpio.c` (new!) provides the public implementation,
 which validates and dispatches:
 
 ```c
 hal_status_t hal_gpio_init(hal_gpio_pin_t pin, const hal_gpio_config_t *cfg) {
     if (!cfg) return HAL_ERR_INVALID_ARG;
-    if (cfg->mode == HAL_GPIO_MODE_AF && cfg->alternate == HAL_GPIO_AF_NONE)
-        return HAL_ERR_INVALID_ARG;
-    return _hal_gpio_ops->init(pin, cfg);
+    return _hal_gpio_ops.init(pin, cfg);
 }
 ```
+
+> The illustrative `cfg->alternate == HAL_GPIO_AF_NONE` rule from earlier
+> drafts is deferred: the current port API has no `HAL_GPIO_AF_NONE`
+> sentinel, so the first GPIO migration hoists only the genuinely
+> duplicated check (the NULL `cfg`) to stay behaviour-preserving. Richer
+> shared validation can follow once the sentinel exists.
 
 Vendor `src/vendor/stm32/gpio/gpio.c` becomes:
 
 ```c
-static hal_status_t stm32_gpio_init_impl(hal_gpio_pin_t pin, const hal_gpio_config_t *cfg) {
+static hal_status_t stm32_gpio_init(hal_gpio_pin_t pin, const hal_gpio_config_t *cfg) {
     /* register-poking only — validation already happened upstream */
     ...
 }
 
-static const hal_gpio_ops_t stm32_gpio_ops = {
-    .init     = stm32_gpio_init_impl,
-    .set_mode = stm32_gpio_set_mode_impl,
+const hal_gpio_ops_t _hal_gpio_ops = {
+    .init     = stm32_gpio_init,
+    .set_mode = stm32_gpio_set_mode,
     /* … */
 };
-
-const hal_gpio_ops_t *const _hal_gpio_ops = &stm32_gpio_ops;
 ```
 
 ### 9.2 — Per-subsystem migration
@@ -100,7 +105,7 @@ Roll this out one subsystem at a time so each step is reviewable:
 
 | Order | Subsystem      | Why this order |
 |---|---|---|
-| 1 | GPIO           | Smallest stable surface, most heavily duplicated, lowest risk |
+| 1 | GPIO ✅ done    | Smallest stable surface, most heavily duplicated, lowest risk |
 | 2 | UART           | Second-smallest surface; sets the pattern for "options struct" |
 | 3 | INTERRUPT      | Architecture-touching but the pattern is similar |
 | 4 | TIMER + PWM    | Closely related, do them together |
@@ -166,10 +171,13 @@ implement the HAL" gate that's missing today.
 
 ## Open questions
 
-* Should the vtable be a `const struct` at fixed address (Zephyr's
+* ~~Should the vtable be a `const struct` at fixed address (Zephyr's
   pattern, devirtualises under LTO) or function-pointer-via-getter
-  (more flexible, slower)? Probably the former — embedded targets
-  prize the perf.
+  (more flexible, slower)?~~ **Resolved (GPIO migration):** a `const`
+  table embedded directly — `extern const hal_gpio_ops_t _hal_gpio_ops;`,
+  not a pointer-to-table. This drops one indirection and devirtualises
+  under `-flto`. The hot paths (write/read/toggle) stay `static inline`
+  in the port header and never enter the table.
 * What about subsystems where vendor implementations are *wildly*
   different — e.g., a chip with hardware multi-master I²C arbitration
   that needs APIs the rest don't have? Two options: extend the ops

--- a/include/internal/hal_gpio_ops.h
+++ b/include/internal/hal_gpio_ops.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2025 NAVRobotec Pvt Ltd
+ * Author: Ragnar Vallhala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file internal/hal_gpio_ops.h
+ * @brief HAL-internal GPIO vendor-backend interface (the driver vtable).
+ *
+ * @details
+ * This header is **not part of the public API** — application code includes
+ * @c common/hal_gpio.h, never this file. It declares the per-vendor operations
+ * table that the shared public layer (@c src/common/hal_gpio.c) dispatches
+ * through. Each port supplies exactly one definition of ::_hal_gpio_ops with
+ * its register-poking implementations; adding a vendor means filling in this
+ * table, not re-declaring the public API.
+ *
+ * The table is embedded **directly** (a @c const object, not a
+ * pointer-to-table): this drops one level of indirection on every dispatch,
+ * and because the object is @c const and resolved at link time, @c -flto
+ * devirtualises the indirect call back to a direct call (and inlines it) on a
+ * release build. See @ref roadmap_abstraction for the measured per-arch costs.
+ *
+ * Hot-path accessors (write / read / toggle) are deliberately **not** in this
+ * table — they stay @c static @c inline in the port header so a constant pin
+ * still folds to a single instruction.
+ */
+
+#ifndef NAVHAL_INTERNAL_HAL_GPIO_OPS_H
+#define NAVHAL_INTERNAL_HAL_GPIO_OPS_H
+
+#include "common/hal_gpio.h"
+#include "common/hal_status.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Per-vendor GPIO operations table.
+ *
+ * One function pointer per public @c hal_gpio_* configuration call. The
+ * shared public layer validates arguments once, then dispatches here. A port
+ * that leaves an entry NULL is caught at build time
+ * (@c -Wmissing-field-initializers) or, failing that, at the call site.
+ */
+typedef struct {
+  /** Backend for ::hal_gpio_init. Validation (NULL @p cfg) has already run. */
+  hal_status_t (*init)(hal_gpio_pin_t pin, const hal_gpio_config_t *cfg);
+  /** Backend for ::hal_gpio_set_mode. */
+  hal_status_t (*set_mode)(hal_gpio_pin_t pin, hal_gpio_mode_t mode,
+                           hal_gpio_pull_t pull);
+  /** Backend for ::hal_gpio_get_mode. */
+  hal_gpio_mode_t (*get_mode)(hal_gpio_pin_t pin);
+  /** Backend for ::hal_gpio_enable_clock. */
+  hal_status_t (*enable_clock)(hal_gpio_pin_t pin);
+  /** Backend for ::hal_gpio_set_alternate_function. */
+  hal_status_t (*set_alternate_function)(hal_gpio_pin_t pin, hal_gpio_af_t af);
+  /** Backend for ::hal_gpio_set_output_type. */
+  hal_status_t (*set_output_type)(hal_gpio_pin_t pin,
+                                  hal_gpio_output_type_t type);
+  /** Backend for ::hal_gpio_set_output_speed. */
+  hal_status_t (*set_output_speed)(hal_gpio_pin_t pin,
+                                   hal_gpio_output_speed_t speed);
+} hal_gpio_ops_t;
+
+/**
+ * @brief The active port's GPIO operations table.
+ *
+ * Defined by exactly one vendor translation unit (e.g.
+ * @c src/vendor/stm32/gpio/gpio.c). NavHAL builds one vendor per firmware, so
+ * the symbol is resolved uniquely at link time.
+ */
+extern const hal_gpio_ops_t _hal_gpio_ops;
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* NAVHAL_INTERNAL_HAL_GPIO_OPS_H */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,13 @@ set(COMMON_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/utils/util.c
 )
 
+# Shared public driver layers (M9 driver vtable): validate + dispatch to the
+# active vendor's ops table. Gated on the same CONFIG_DRV_* symbols as the
+# vendor backends so a firmware that omits a driver omits its public layer too.
+if(CONFIG_DRV_GPIO)
+    list(APPEND COMMON_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/common/hal_gpio.c)
+endif()
+
 if(CONFIG_DRV_SDIO)
     list(APPEND COMMON_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/utils/v_fs.c
@@ -14,3 +21,14 @@ if(CONFIG_DRV_SDIO)
 endif()
 
 add_library(common OBJECT ${COMMON_SOURCES})
+
+# The shared public driver layers include the active port header
+# (common/hal_*.h pulls in navhal_port_*.h), so `common` needs the same
+# port/family/board search paths the vendor `hal` library uses. These vars
+# are set by the root CMakeLists before add_subdirectory(src).
+target_include_directories(common PRIVATE
+    ${INCLUDE_PORT}
+    ${INCLUDE_FAMILY}
+    ${SRC_BOARD}
+    ${CMAKE_BINARY_DIR}
+)

--- a/src/common/hal_gpio.c
+++ b/src/common/hal_gpio.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025 NAVRobotec Pvt Ltd
+ * Author: Ragnar Vallhala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file src/common/hal_gpio.c
+ * @brief Shared public GPIO layer: validate, then dispatch to the vendor vtable.
+ *
+ * @details
+ * This is the one implementation of the public @c hal_gpio_* configuration API
+ * that every port shares. It performs the argument validation that used to be
+ * copy-pasted into each vendor's @c gpio.c (today: the NULL-config check on
+ * ::hal_gpio_init) and then forwards to the active port's ::_hal_gpio_ops
+ * backend. Vendor drivers keep only the register-poking implementations.
+ *
+ * The hot-path accessors (write / read / toggle) are not routed through here —
+ * they remain @c static @c inline in the port header.
+ */
+
+#include "common/hal_gpio.h"
+#include "internal/hal_gpio_ops.h"
+
+#include <stddef.h>
+
+hal_status_t hal_gpio_init(hal_gpio_pin_t pin, const hal_gpio_config_t *cfg) {
+  if (cfg == NULL)
+    return HAL_ERR_INVALID_ARG;
+  return _hal_gpio_ops.init(pin, cfg);
+}
+
+hal_status_t hal_gpio_set_mode(hal_gpio_pin_t pin, hal_gpio_mode_t mode,
+                               hal_gpio_pull_t pull) {
+  return _hal_gpio_ops.set_mode(pin, mode, pull);
+}
+
+hal_gpio_mode_t hal_gpio_get_mode(hal_gpio_pin_t pin) {
+  return _hal_gpio_ops.get_mode(pin);
+}
+
+hal_status_t hal_gpio_enable_clock(hal_gpio_pin_t pin) {
+  return _hal_gpio_ops.enable_clock(pin);
+}
+
+hal_status_t hal_gpio_set_alternate_function(hal_gpio_pin_t pin,
+                                             hal_gpio_af_t af) {
+  return _hal_gpio_ops.set_alternate_function(pin, af);
+}
+
+hal_status_t hal_gpio_set_output_type(hal_gpio_pin_t pin,
+                                      hal_gpio_output_type_t type) {
+  return _hal_gpio_ops.set_output_type(pin, type);
+}
+
+hal_status_t hal_gpio_set_output_speed(hal_gpio_pin_t pin,
+                                       hal_gpio_output_speed_t speed) {
+  return _hal_gpio_ops.set_output_speed(pin, speed);
+}

--- a/src/vendor/microchip/gpio/gpio.c
+++ b/src/vendor/microchip/gpio/gpio.c
@@ -17,23 +17,27 @@
 
 /**
  * @file src/vendor/microchip/gpio/gpio.c
- * @brief ATmega328P GPIO HAL driver.
+ * @brief ATmega328P GPIO vendor backend.
  *
  * @details
- * Implements the portable GPIO API (@c common/hal_gpio.h) for the
- * ATmega328P ports B, C and D — the configuration calls (init, set_mode,
- * …). The hot-path accessors (write / read / toggle) are @c static
- * @c inline in @c navhal_port_gpio.h so a constant pin folds to `sbi`/`cbi`.
- * A ::hal_gpio_pin_t is encoded 8 per port: @c port = pin >> 3
- * (0 = B, 1 = C, 2 = D), @c bit = pin & 7.
+ * Provides the ATmega328P implementations behind the GPIO driver vtable
+ * (::hal_gpio_ops_t). Argument validation (the NULL-config check) lives once
+ * in the shared public layer @c src/common/hal_gpio.c, so these operations do
+ * register work only. The active table is published as ::_hal_gpio_ops at the
+ * bottom of this file.
  *
- * ATmega328P GPIO has no clock gate, no slew-rate control, no open-drain
+ * Ports B, C and D are addressed 8 pins each: @c port = pin >> 3
+ * (0 = B, 1 = C, 2 = D), @c bit = pin & 7. The hot-path accessors (write /
+ * read / toggle) are @c static @c inline in @c navhal_port_gpio.h so a
+ * constant pin folds to `sbi`/`cbi`.
+ *
+ * The ATmega328P GPIO has no clock gate, no slew-rate control, no open-drain
  * mode and no alternate-function multiplexer in the STM32 sense, so the
- * corresponding config knobs are accepted as no-ops (or, for alternate
- * function, reported unsupported).
+ * corresponding knobs are accepted as no-ops (or, for alternate function,
+ * reported unsupported).
  */
 
-#include "navhal_port_gpio.h"
+#include "internal/hal_gpio_ops.h"
 
 #include <avr/io.h>
 #include <stddef.h>
@@ -56,8 +60,8 @@ static volatile uint8_t *port_out_reg(uint8_t port) {
   }
 }
 
-hal_status_t hal_gpio_set_mode(hal_gpio_pin_t pin, hal_gpio_mode_t mode,
-                               hal_gpio_pull_t pull) {
+static hal_status_t avr_gpio_set_mode(hal_gpio_pin_t pin, hal_gpio_mode_t mode,
+                                      hal_gpio_pull_t pull) {
   uint8_t p = (uint8_t)pin >> 3;
   uint8_t m = (uint8_t)(1u << ((uint8_t)pin & 7u));
   volatile uint8_t *ddr = ddr_reg(p);
@@ -78,27 +82,27 @@ hal_status_t hal_gpio_set_mode(hal_gpio_pin_t pin, hal_gpio_mode_t mode,
   return HAL_OK;
 }
 
-hal_status_t hal_gpio_init(hal_gpio_pin_t pin, const hal_gpio_config_t *cfg) {
-  if (cfg == NULL)
-    return HAL_ERR_INVALID_ARG;
-  /* output_type, output_speed and alternate have no ATmega328P effect. */
-  return hal_gpio_set_mode(pin, cfg->mode, cfg->pull);
+static hal_status_t avr_gpio_init(hal_gpio_pin_t pin,
+                                  const hal_gpio_config_t *cfg) {
+  /* cfg is non-NULL: the public layer validated it before dispatching.
+   * output_type, output_speed and alternate have no ATmega328P effect. */
+  return avr_gpio_set_mode(pin, cfg->mode, cfg->pull);
 }
 
-hal_gpio_mode_t hal_gpio_get_mode(hal_gpio_pin_t pin) {
+static hal_gpio_mode_t avr_gpio_get_mode(hal_gpio_pin_t pin) {
   uint8_t p = (uint8_t)pin >> 3;
   uint8_t m = (uint8_t)(1u << ((uint8_t)pin & 7u));
   return (*ddr_reg(p) & m) ? HAL_GPIO_MODE_OUTPUT : HAL_GPIO_MODE_INPUT;
 }
 
-hal_status_t hal_gpio_enable_clock(hal_gpio_pin_t pin) {
+static hal_status_t avr_gpio_enable_clock(hal_gpio_pin_t pin) {
   /* ATmega328P GPIO ports are always clocked — nothing to enable. */
   (void)pin;
   return HAL_OK;
 }
 
-hal_status_t hal_gpio_set_alternate_function(hal_gpio_pin_t pin,
-                                             hal_gpio_af_t af) {
+static hal_status_t avr_gpio_set_alternate_function(hal_gpio_pin_t pin,
+                                                    hal_gpio_af_t af) {
   /* The ATmega328P has no GPIO alternate-function multiplexer; peripheral
    * pin functions are fixed in silicon. */
   (void)pin;
@@ -106,18 +110,28 @@ hal_status_t hal_gpio_set_alternate_function(hal_gpio_pin_t pin,
   return HAL_ERR_NOT_SUPPORTED;
 }
 
-hal_status_t hal_gpio_set_output_type(hal_gpio_pin_t pin,
-                                      hal_gpio_output_type_t type) {
+static hal_status_t avr_gpio_set_output_type(hal_gpio_pin_t pin,
+                                             hal_gpio_output_type_t type) {
   /* ATmega328P outputs are push-pull only; accepted as a no-op. */
   (void)pin;
   (void)type;
   return HAL_OK;
 }
 
-hal_status_t hal_gpio_set_output_speed(hal_gpio_pin_t pin,
-                                       hal_gpio_output_speed_t speed) {
+static hal_status_t avr_gpio_set_output_speed(hal_gpio_pin_t pin,
+                                              hal_gpio_output_speed_t speed) {
   /* No slew-rate control on the ATmega328P; accepted as a no-op. */
   (void)pin;
   (void)speed;
   return HAL_OK;
 }
+
+const hal_gpio_ops_t _hal_gpio_ops = {
+    .init = avr_gpio_init,
+    .set_mode = avr_gpio_set_mode,
+    .get_mode = avr_gpio_get_mode,
+    .enable_clock = avr_gpio_enable_clock,
+    .set_alternate_function = avr_gpio_set_alternate_function,
+    .set_output_type = avr_gpio_set_output_type,
+    .set_output_speed = avr_gpio_set_output_speed,
+};

--- a/src/vendor/stm32/gpio/gpio.c
+++ b/src/vendor/stm32/gpio/gpio.c
@@ -17,29 +17,34 @@
 
 /**
  * @file gpio.c
- * @brief Standardized HAL GPIO driver implementation for STM32F4 (Cortex-M4).
+ * @brief STM32F4 (Cortex-M4) GPIO vendor backend.
  *
  * @details
- * Implements the standardized `hal_gpio_*` API declared in
- * `port/cortex-m4/navhal_port_gpio.h`: pin configuration, mode/pull/alternate-function
- * setup, output type/speed, and port clock enabling. The hot-path
- * write/read/toggle helpers are defined `static inline` in the header.
+ * Provides the STM32F4 implementations behind the GPIO driver vtable
+ * (::hal_gpio_ops_t, declared in @c internal/hal_gpio_ops.h). These are the
+ * register-poking operations only — argument validation (e.g. the NULL-config
+ * check) lives once in the shared public layer @c src/common/hal_gpio.c and
+ * has already run by the time these are called. The active table is published
+ * as ::_hal_gpio_ops at the bottom of this file.
+ *
+ * The hot-path write/read/toggle helpers stay @c static @c inline in
+ * @c port/cortex-m4/navhal_port_gpio.h.
  */
 
-#include "navhal_port_gpio.h"
+#include "internal/hal_gpio_ops.h"
 #include "family/gpio_reg.h"
 #include "family/rcc_reg.h"
 
-hal_status_t hal_gpio_enable_clock(hal_gpio_pin_t pin) {
+static hal_status_t stm32_gpio_enable_clock(hal_gpio_pin_t pin) {
   uint32_t port = GPIO_GET_PORT_NUMBER(pin);
   if (!(RCC->AHB1ENR & (1U << port)))
     RCC->AHB1ENR |= (1U << port);
   return HAL_OK;
 }
 
-hal_status_t hal_gpio_set_mode(hal_gpio_pin_t pin, hal_gpio_mode_t mode,
-                               hal_gpio_pull_t pull) {
-  hal_gpio_enable_clock(pin); // Ensure GPIO port clock enabled
+static hal_status_t stm32_gpio_set_mode(hal_gpio_pin_t pin, hal_gpio_mode_t mode,
+                                        hal_gpio_pull_t pull) {
+  stm32_gpio_enable_clock(pin); // Ensure GPIO port clock enabled
 
   uint32_t shift = GPIO_GET_PIN(pin) * 2;
 
@@ -54,15 +59,15 @@ hal_status_t hal_gpio_set_mode(hal_gpio_pin_t pin, hal_gpio_mode_t mode,
   return HAL_OK;
 }
 
-hal_gpio_mode_t hal_gpio_get_mode(hal_gpio_pin_t pin) {
+static hal_gpio_mode_t stm32_gpio_get_mode(hal_gpio_pin_t pin) {
   return (hal_gpio_mode_t)((GPIO_GET_PORT(pin)->MODER >>
                             (GPIO_GET_PIN(pin) * 2)) &
                            0x3U);
 }
 
-hal_status_t hal_gpio_set_alternate_function(hal_gpio_pin_t pin,
-                                             hal_gpio_af_t af) {
-  hal_gpio_set_mode(pin, HAL_GPIO_MODE_AF, HAL_GPIO_PULL_NONE);
+static hal_status_t stm32_gpio_set_alternate_function(hal_gpio_pin_t pin,
+                                                      hal_gpio_af_t af) {
+  stm32_gpio_set_mode(pin, HAL_GPIO_MODE_AF, HAL_GPIO_PULL_NONE);
 
   uint8_t pin_num = GPIO_GET_PIN(pin);
   uint32_t mask = 0xFU << (4 * (pin_num % 8));
@@ -76,15 +81,15 @@ hal_status_t hal_gpio_set_alternate_function(hal_gpio_pin_t pin,
   return HAL_OK;
 }
 
-hal_status_t hal_gpio_set_output_type(hal_gpio_pin_t pin,
-                                      hal_gpio_output_type_t type) {
+static hal_status_t stm32_gpio_set_output_type(hal_gpio_pin_t pin,
+                                               hal_gpio_output_type_t type) {
   GPIO_GET_PORT(pin)->OTYPER &= ~(0x1U << GPIO_GET_PIN(pin));
   GPIO_GET_PORT(pin)->OTYPER |= (((uint32_t)type & 0x1U) << GPIO_GET_PIN(pin));
   return HAL_OK;
 }
 
-hal_status_t hal_gpio_set_output_speed(hal_gpio_pin_t pin,
-                                       hal_gpio_output_speed_t speed) {
+static hal_status_t stm32_gpio_set_output_speed(hal_gpio_pin_t pin,
+                                                hal_gpio_output_speed_t speed) {
   /* OSPEEDR is 2 bits per pin (M4 RM0383 §8.4.3); the shift must scale. */
   uint32_t shift = GPIO_GET_PIN(pin) * 2;
   GPIO_GET_PORT(pin)->OSPEEDR &= ~(0x3U << shift);
@@ -92,18 +97,27 @@ hal_status_t hal_gpio_set_output_speed(hal_gpio_pin_t pin,
   return HAL_OK;
 }
 
-hal_status_t hal_gpio_init(hal_gpio_pin_t pin, const hal_gpio_config_t *cfg) {
-  if (cfg == NULL)
-    return HAL_ERR_INVALID_ARG;
-
-  hal_gpio_set_mode(pin, cfg->mode, cfg->pull);
+static hal_status_t stm32_gpio_init(hal_gpio_pin_t pin,
+                                    const hal_gpio_config_t *cfg) {
+  /* cfg is non-NULL: the public layer validated it before dispatching. */
+  stm32_gpio_set_mode(pin, cfg->mode, cfg->pull);
 
   if (cfg->mode == HAL_GPIO_MODE_OUTPUT || cfg->mode == HAL_GPIO_MODE_AF) {
-    hal_gpio_set_output_type(pin, cfg->output_type);
-    hal_gpio_set_output_speed(pin, cfg->output_speed);
+    stm32_gpio_set_output_type(pin, cfg->output_type);
+    stm32_gpio_set_output_speed(pin, cfg->output_speed);
   }
   if (cfg->mode == HAL_GPIO_MODE_AF)
-    hal_gpio_set_alternate_function(pin, cfg->alternate);
+    stm32_gpio_set_alternate_function(pin, cfg->alternate);
 
   return HAL_OK;
 }
+
+const hal_gpio_ops_t _hal_gpio_ops = {
+    .init = stm32_gpio_init,
+    .set_mode = stm32_gpio_set_mode,
+    .get_mode = stm32_gpio_get_mode,
+    .enable_clock = stm32_gpio_enable_clock,
+    .set_alternate_function = stm32_gpio_set_alternate_function,
+    .set_output_type = stm32_gpio_set_output_type,
+    .set_output_speed = stm32_gpio_set_output_speed,
+};


### PR DESCRIPTION
## M9 — driver vtable, subsystem 1 (GPIO)

First subsystem migration of the M9 vendor-backend abstraction (`docs/roadmap/M9-driver-vtable.md`). Replaces "vendor = copy and re-implement the public API" with a shared validate-and-dispatch layer over a per-vendor operations table.

### What changed
- **New `include/internal/hal_gpio_ops.h`** — the GPIO driver vtable (`hal_gpio_ops_t`, one entry per public `hal_gpio_*` config call) and `extern const hal_gpio_ops_t _hal_gpio_ops;`. The table is **embedded directly** (a `const` object, not a pointer-to-table): drops one indirection and devirtualises under `-flto`. Resolves the §9.1 open question.
- **New `src/common/hal_gpio.c`** — the shared public layer. Hoists the duplicated NULL-config check into `hal_gpio_init`, then dispatches every call through `_hal_gpio_ops`.
- **`src/vendor/{stm32,microchip}/gpio/gpio.c`** — now register-poking `static` impls plus their ops table; no more copies of the public API or its validation.
- **Hot paths untouched** — `write`/`read`/`toggle` stay `static inline` in the port headers and never enter the table, so GPIO's perf exit criterion is met by construction.
- **Build** — the public layer compiles into the `common` object library (gated on `CONFIG_DRV_GPIO`), which gains the port/family/board include paths.

### Verification (behaviour-preserving)
| Gate | Result |
|---|---|
| Host suite | 24/24 pass |
| PIL conformance — Cortex-M4 | 143/143 pass |
| PIL conformance — AVR ATmega328P | 36/36 pass |
| Build all Cortex samples | 28/28 |
| Build all AVR portable samples | 12/12 |

### Scope / follow-ups
This is the GPIO migration only — it sets the pattern for subsystems 2–8 (UART next). The cross-cutting M9 infra items (an `-flto` release config and a cycle-counted regression test) are intentionally deferred to a focused follow-up.