### PR TITLE
build: require a SemVer bump for every merge into stable

### DIFF
--- a/.github/workflows/semver-gate.yml
+++ b/.github/workflows/semver-gate.yml
@@ -1,0 +1,87 @@
+# Semver gate — every merge into `stable` must raise the release version.
+#
+# Runs on PRs targeting `stable`. Parses the SemVer release version from
+# include/navhal.h (VERSION_MAJOR/MINOR/PATCH — the single source of truth;
+# CMakeLists.txt refuses to build if its mirror and navhal.h disagree) on the
+# PR head and compares it to the version currently on `stable`. The job fails
+# unless the head version is a valid SemVer strictly greater than the base.
+#
+# Why pull_request_target (not pull_request): for `pull_request`, GitHub runs
+# the workflow file from the PR's head, so a contributor could weaken or delete
+# this gate in their own PR. `pull_request_target` always uses the copy on the
+# base branch (`stable`), so the gate cannot be bypassed from a PR. We never
+# check out or execute the PR's code — we only read one file via `git show` —
+# so the usual pull_request_target code-execution risk does not apply, and the
+# token is restricted to contents:read.
+#
+# Make the "Semver bump required" check a REQUIRED status check on the `stable`
+# branch protection rule so a PR cannot merge without it passing.
+
+name: Semver gate
+
+on:
+  pull_request_target:
+    branches: [stable]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: semver-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  semver-bump:
+    name: Semver bump required
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out base (stable)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Require a SemVer bump in include/navhal.h
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          # Bring the PR head commit into a local ref WITHOUT merging or running
+          # any of its code. Works for same-repo and fork PRs alike, since
+          # GitHub publishes the head at refs/pull/<n>/head on the base repo.
+          git fetch --no-tags --depth 1 origin "refs/pull/${PR_NUMBER}/head:pr-head"
+
+          # Parse "x.y.z" from VERSION_MAJOR/MINOR/PATCH in navhal.h at a ref.
+          extract() {
+            local ref=$1 blob maj min pat
+            blob=$(git show "${ref}:include/navhal.h")
+            maj=$(printf '%s\n' "$blob" | sed -nE 's/^#define[[:space:]]+VERSION_MAJOR[[:space:]]+([0-9]+).*/\1/p' | head -1)
+            min=$(printf '%s\n' "$blob" | sed -nE 's/^#define[[:space:]]+VERSION_MINOR[[:space:]]+([0-9]+).*/\1/p' | head -1)
+            pat=$(printf '%s\n' "$blob" | sed -nE 's/^#define[[:space:]]+VERSION_PATCH[[:space:]]+([0-9]+).*/\1/p' | head -1)
+            if [ -z "$maj" ] || [ -z "$min" ] || [ -z "$pat" ]; then
+              echo "::error::could not parse VERSION_MAJOR/MINOR/PATCH from include/navhal.h at ${ref}" >&2
+              return 1
+            fi
+            printf '%s.%s.%s\n' "$maj" "$min" "$pat"
+          }
+
+          BASE_VER=$(extract "${BASE_SHA}")
+          HEAD_VER=$(extract "pr-head")
+          echo "stable (base) version : ${BASE_VER}"
+          echo "PR     (head) version : ${HEAD_VER}"
+
+          # Strict SemVer greater-than on the numeric triple.
+          IFS=. read -r bM bm bp <<<"$BASE_VER"
+          IFS=. read -r hM hm hp <<<"$HEAD_VER"
+          newer=0
+          if   [ "$hM" -gt "$bM" ]; then newer=1
+          elif [ "$hM" -eq "$bM" ] && [ "$hm" -gt "$bm" ]; then newer=1
+          elif [ "$hM" -eq "$bM" ] && [ "$hm" -eq "$bm" ] && [ "$hp" -gt "$bp" ]; then newer=1
+          fi
+
+          if [ "$newer" -ne 1 ]; then
+            echo "::error::Merging into stable requires a SemVer bump in include/navhal.h (base=${BASE_VER}, head=${HEAD_VER}; head must be strictly greater)."
+            exit 1
+          fi
+          echo "OK: ${BASE_VER} -> ${HEAD_VER} is a valid SemVer bump."

--- a/.github/workflows/stable-ci.yml
+++ b/.github/workflows/stable-ci.yml
@@ -1,0 +1,95 @@
+# Slim per-PR suite for `stable`.
+#
+# `stable` accepts PRs from any branch (not only promotions from `main`), so it
+# needs its own CI that runs directly on PRs into `stable`. We deliberately do
+# NOT mirror main's full release gate here: main's heavier gates (license-header
+# sweep, Doxygen-strict, all-samples / AVR / PIL builds, capability contract)
+# assume main's tree and tooling and do not pass against stable's older tree.
+# This runs the checks that are meaningful and green on stable:
+#
+#   Host tests · Host tests under ASan + UBSan · Reproducible build (soft)
+#
+# The SemVer-bump requirement is enforced separately by semver-gate.yml.
+#
+# Required status checks on stable's branch protection:
+#   Host tests, Host tests under ASan + UBSan, Semver bump required
+# (Reproducible build is soft / continue-on-error and is intentionally not
+# required.)
+
+name: Stable CI
+
+on:
+  pull_request:
+    branches: [stable]
+  workflow_dispatch:
+
+concurrency:
+  group: stable-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  host-tests:
+    name: Host tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure host build
+        run: cmake -B build-host -S tests/host
+      - name: Build host tests
+        run: cmake --build build-host -j
+      - name: Run host tests
+        run: ./build-host/tests_host
+
+  sanitizer-host:
+    name: Host tests under ASan + UBSan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure with sanitizers
+        run: |
+          cmake -B build-host-san -S tests/host \
+            -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g -O1" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
+      - name: Build
+        run: cmake --build build-host-san -j
+      - name: Run
+        env:
+          ASAN_OPTIONS: "halt_on_error=1:abort_on_error=1:detect_leaks=1"
+          UBSAN_OPTIONS: "halt_on_error=1:print_stacktrace=1"
+        run: ./build-host-san/tests_host
+
+  # Soft reproducibility check — builds the test ELF twice and compares the
+  # stripped .bin. continue-on-error: the project does not yet wire
+  # -fdebug-prefix-map / SOURCE_DATE_EPOCH, so this reports but never blocks.
+  reproducible-build:
+    name: Reproducible build (soft)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install arm-none-eabi + kconfiglib
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            gcc-arm-none-eabi binutils-arm-none-eabi libnewlib-arm-none-eabi
+          pip install kconfiglib
+      - name: Build A
+        run: |
+          cmake -B build-a -DTEST=ON >/dev/null
+          cmake --build build-a --target tests -j >/dev/null
+          arm-none-eabi-objcopy -O binary build-a/tests build-a/tests.bin
+      - name: Build B (fresh)
+        run: |
+          rm -f .config
+          rm -rf build-b
+          cmake -B build-b -DTEST=ON >/dev/null
+          cmake --build build-b --target tests -j >/dev/null
+          arm-none-eabi-objcopy -O binary build-b/tests build-b/tests.bin
+      - name: Compare
+        run: |
+          if cmp -s build-a/tests.bin build-b/tests.bin; then
+            echo "::notice::tests.bin is bit-for-bit reproducible"
+          else
+            echo "::warning::tests.bin differs across builds."
+            cmp build-a/tests.bin build-b/tests.bin || true
+          fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,29 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
 # set(SYSROOT "/opt/homebrew/Cellar/arm-none-eabi-gcc/15.1.0/lib/gcc/arm-none-eabi/15.1.0")
 # extern/NavHAL/CMakeLists.txt
 #
+# ---- Release version --------------------------------------------------------
+# include/navhal.h is the single source of truth for the SemVer release version
+# (it is the header applications include). We mirror it here so the build and
+# tooling can use ${PROJECT_VERSION}, and we FATAL_ERROR if the two ever
+# disagree: bumping one without the other is a release-process bug, not
+# something we want to silently build. This check runs on every configure,
+# including when NavHAL is consumed as a submodule.
+set(NAVHAL_VERSION 0.1.0) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/include/navhal.h" _navhal_h)
+string(REGEX MATCH "#define[ \t]+VERSION_MAJOR[ \t]+([0-9]+)" _ "${_navhal_h}")
+set(_navhal_h_major "${CMAKE_MATCH_1}")
+string(REGEX MATCH "#define[ \t]+VERSION_MINOR[ \t]+([0-9]+)" _ "${_navhal_h}")
+set(_navhal_h_minor "${CMAKE_MATCH_1}")
+string(REGEX MATCH "#define[ \t]+VERSION_PATCH[ \t]+([0-9]+)" _ "${_navhal_h}")
+set(_navhal_h_patch "${CMAKE_MATCH_1}")
+set(_navhal_h_version "${_navhal_h_major}.${_navhal_h_minor}.${_navhal_h_patch}")
+if(NOT NAVHAL_VERSION STREQUAL _navhal_h_version)
+    message(FATAL_ERROR
+        "NavHAL version mismatch: CMakeLists NAVHAL_VERSION='${NAVHAL_VERSION}' but "
+        "include/navhal.h declares '${_navhal_h_version}'. navhal.h is the source of "
+        "truth — bump VERSION_MAJOR/MINOR/PATCH and NAVHAL_VERSION together.")
+endif()
+#
 # project() enables the C/ASM languages and must run on EVERY configure.
 # Guarding it on CMAKE_PROJECT_NAME (a cache variable) made it run only on the
 # first configure of a build directory — every later reconfigure skipped it,
@@ -58,7 +81,7 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
 # target ..."). Detect the top-level build via a path comparison instead, which
 # is re-evaluated fresh each configure and is true only for a standalone build.
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-    project(NavHAL C ASM)
+    project(NavHAL VERSION ${NAVHAL_VERSION} LANGUAGES C ASM)
 endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)


### PR DESCRIPTION
## What

Enforce that every merge into `stable` raises the release version.

- **`.github/workflows/semver-gate.yml`** — a `pull_request_target` gate on PRs targeting `stable`. It parses the SemVer release version from `include/navhal.h` (`VERSION_MAJOR/MINOR/PATCH`) on the PR head and compares it to the version on `stable`. The job fails unless the head version is a valid SemVer **strictly greater** than the base.
- **`CMakeLists.txt`** — mirrors the version into `project(... VERSION ...)` and raises `FATAL_ERROR` if the CMake mirror and `navhal.h` ever disagree, so the two can't silently drift. Runs on every configure, including when NavHAL is consumed as a submodule.

`include/navhal.h` stays the single source of truth for the release version. `HAL_API_VERSION` is unaffected (it is a separate, frozen API-contract version).

## Why `pull_request_target`

For a plain `pull_request`, GitHub runs the workflow file from the PR's head branch, so a contributor could weaken or delete the gate from within their own PR. `pull_request_target` always uses the copy on the base branch (`stable`), so the gate cannot be bypassed. It never checks out or runs PR code — it only reads one file via `git show` — and the token is restricted to `contents: read`.

## Required follow-up after merge

This PR is intentionally **not** gated by the semver rule, because the workflow does not exist on `stable`'s base yet. Once merged, add **`Semver bump required`** to `stable`'s required status checks (branch protection) so it is enforced from then on. Adding it before the workflow is on `stable` would deadlock this PR on a check that can never report.

## Notes

- Direct pushes to `stable` are already blocked (pull request required, admins included, force-push and deletion disabled).
- Verified locally: the CMake parse/mismatch check (`cmake -P`), the workflow YAML validity, and the strict greater-than comparison (same or lower version → reject; patch/minor/major bump → accept).
