### PR TITLE
feat(uart): IDLE-line callback + DMA RX index (0.2.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 # disagree: bumping one without the other is a release-process bug, not
 # something we want to silently build. This check runs on every configure,
 # including when NavHAL is consumed as a submodule.
-set(NAVHAL_VERSION 0.2.0) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
+set(NAVHAL_VERSION 0.2.1) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/include/navhal.h" _navhal_h)
 string(REGEX MATCH "#define[ \t]+VERSION_MAJOR[ \t]+([0-9]+)" _ "${_navhal_h}")
 set(_navhal_h_major "${CMAKE_MATCH_1}")

--- a/include/navhal.h
+++ b/include/navhal.h
@@ -36,8 +36,8 @@
 /* Release version (SemVer) — the version of this NavHAL distribution. */
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 2
-#define VERSION_PATCH 0
-#define VERSION "0.2.0"
+#define VERSION_PATCH 1
+#define VERSION "0.2.1"
 
 /**
  * @brief NavHAL public-API contract version.

--- a/include/port/cortex-m4/navhal_port_uart.h
+++ b/include/port/cortex-m4/navhal_port_uart.h
@@ -42,6 +42,31 @@ extern "C" {
    independently of other DMA users. */
 
 /* -------------------------------------------------------------------------- *
+ * IDLE-line interrupt → callback (DMA-independent).
+ *
+ * Lets a consumer wake on the inter-frame gap of a byte-oriented protocol
+ * (SBUS/iBUS/etc.) instead of polling. Typically paired with circular DMA RX:
+ * arm DMA, then attach an idle callback that signals a task to drain the ring.
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @brief Enable the UART IDLE-line interrupt and route it to @p callback.
+ *
+ * The IDLE flag is cleared inside the driver before @p callback runs. The line
+ * is enabled at a maskable (BASEPRI-managed) NVIC priority, so @p callback may
+ * call an RTOS @c *_from_isr primitive (e.g. give a semaphore).
+ *
+ * @param uart      Target UART.
+ * @param callback  Invoked from ISR context on each detected idle frame-gap.
+ * @return HAL_OK, or HAL_ERR_INVALID_ARG for an unknown UART / NULL callback.
+ */
+hal_status_t hal_uart_attach_idle_callback(hal_uart_t uart,
+                                           void (*callback)(void));
+
+/** @brief Disable the IDLE-line interrupt and clear the registered callback. */
+hal_status_t hal_uart_detach_idle_callback(hal_uart_t uart);
+
+/* -------------------------------------------------------------------------- *
  * DMA-backed UART API — available only when the DMA backend is enabled.
  * -------------------------------------------------------------------------- */
 #if defined(_DMA_ENABLED) && defined(_UART_BACKEND_DMA)
@@ -52,6 +77,18 @@ hal_status_t hal_uart_write_dma(hal_uart_t uart, const uint8_t *data,
 /** @brief Set up a UART for DMA-based circular reception. */
 hal_status_t hal_uart_init_dma_rx(hal_uart_t uart, uint8_t *buffer,
                                   uint16_t length);
+/**
+ * @brief Current circular RX write index for a UART set up via
+ *        ::hal_uart_init_dma_rx (i.e. @c length-NDTR on the correct stream).
+ *
+ * Lets consumers track how far the DMA has filled the ring without touching
+ * DMA registers themselves. Valid range is [0, length).
+ *
+ * @param uart       UART previously initialised for DMA RX.
+ * @param out_index  Receives the next-write index.
+ * @return HAL_OK, or HAL_ERR_INVALID_ARG if RX DMA isn't configured / NULL out.
+ */
+hal_status_t hal_uart_dma_rx_index(hal_uart_t uart, uint16_t *out_index);
 /** @brief Transmit a null-terminated string using DMA. */
 hal_status_t hal_uart_write_string_dma(hal_uart_t uart, const char *s);
 

--- a/src/vendor/stm32/family/stm32f4/include/family/uart_reg.h
+++ b/src/vendor/stm32/family/stm32f4/include/family/uart_reg.h
@@ -81,10 +81,14 @@ typedef struct {
   (1                                                                           \
    << 5) ///< RXNE interrupt enable 0: Interrupt is inhibited 1: An USART
          ///< interrupt is generated whenever RXNE=1 in the USART_SR register
+#define USART_CR1_IDLEIE                                                       \
+  (1 << 4) ///< IDLE line interrupt enable: USART interrupt generated whenever
+           ///< IDLE=1 in the USART_SR register
 
 /* Status register bits */
 #define USART_SR_TXE (1 << 7)  ///< Transmit Data Register Empty
 #define USART_SR_RXNE (1 << 5) ///< Read Data Register Not Empty
+#define USART_SR_IDLE (1 << 4) ///< IDLE line detected (cleared by SR then DR read)
 #define USART_SR_TC (1 << 6)   ///< Transmission Complete
 #define USART_SR_PE (1 << 0)   ///< Parity Error
 #define USART_SR_FE (1 << 1)   ///< Framing Error

--- a/src/vendor/stm32/uart/uart.c
+++ b/src/vendor/stm32/uart/uart.c
@@ -120,6 +120,85 @@ hal_status_t hal_uart_enable_interrupt(hal_uart_t uart, uint8_t rx_en,
   return HAL_OK;
 }
 
+/* -------------------------------------------------------------------------- *
+ * IDLE-line interrupt → user callback.
+ *
+ * The IDLE line fires at the inter-frame gap of a byte-oriented protocol
+ * (e.g. SBUS/iBUS), letting a consumer block until a whole frame has arrived
+ * instead of polling. Pairs naturally with circular DMA RX: the DMA fills the
+ * ring, and IDLE signals "a burst just ended — go drain it".
+ * -------------------------------------------------------------------------- */
+
+/** UART -> index into the per-UART tables (UART1=0, UART2=1, UART6=2). */
+static inline int _uart_idx(hal_uart_t uart) {
+  return (uart == HAL_UART_1) ? 0 : (uart == HAL_UART_6) ? 2 : 1;
+}
+
+static void (*_uart_idle_cb[3])(void) = {0};
+
+/* Demux + clear: on the shared USART IRQ, run only if the IDLE flag is set.
+ * F4 has no IDLE-clear bit — the flag is cleared by a read of SR followed by a
+ * read of DR. At IDLE time the line is quiet and DMA has already drained DR, so
+ * the dummy DR read steals no in-flight byte. */
+static void _uart_idle_handle(hal_uart_t uart) {
+  volatile UARTx_Reg_Typedef *usart = _get_usart(uart);
+  if (!usart)
+    return;
+  if (usart->SR & USART_SR_IDLE) {
+    (void)usart->DR; /* SR was just read above; DR read clears IDLE */
+    void (*cb)(void) = _uart_idle_cb[_uart_idx(uart)];
+    if (cb)
+      cb();
+  }
+}
+
+/* The interrupt registry takes a void(void) callback, so one thin trampoline
+ * per USART line carries the UART identity. */
+static void _uart_idle_irq_usart1(void) { _uart_idle_handle(HAL_UART_1); }
+static void _uart_idle_irq_usart2(void) { _uart_idle_handle(HAL_UART_2); }
+static void _uart_idle_irq_usart6(void) { _uart_idle_handle(HAL_UART_6); }
+
+hal_status_t hal_uart_attach_idle_callback(hal_uart_t uart,
+                                           void (*callback)(void)) {
+  volatile UARTx_Reg_Typedef *usart = _get_usart(uart);
+  if (!usart || !callback)
+    return HAL_ERR_INVALID_ARG;
+
+  hal_irq_t irq;
+  void (*trampoline)(void);
+  if (uart == HAL_UART_1) {
+    irq = USART1_IRQn;
+    trampoline = _uart_idle_irq_usart1;
+  } else if (uart == HAL_UART_6) {
+    irq = USART6_IRQn;
+    trampoline = _uart_idle_irq_usart6;
+  } else {
+    irq = USART2_IRQn;
+    trampoline = _uart_idle_irq_usart2;
+  }
+
+  _uart_idle_cb[_uart_idx(uart)] = callback;
+  hal_interrupt_attach_callback(irq, trampoline);
+
+  (void)usart->SR; /* clear any stale IDLE (SR then DR) before arming */
+  (void)usart->DR;
+  usart->CR1 |= USART_CR1_IDLEIE;
+
+  /* Maskable (BASEPRI-managed) priority so the callback may call an RTOS
+   * *_from_isr primitive — same contract as the DMA-completion ISRs. */
+  hal_interrupt_enable_with_priority(irq, HAL_IRQ_PRIORITY_DEFAULT);
+  return HAL_OK;
+}
+
+hal_status_t hal_uart_detach_idle_callback(hal_uart_t uart) {
+  volatile UARTx_Reg_Typedef *usart = _get_usart(uart);
+  if (!usart)
+    return HAL_ERR_INVALID_ARG;
+  usart->CR1 &= ~USART_CR1_IDLEIE;
+  _uart_idle_cb[_uart_idx(uart)] = NULL;
+  return HAL_OK;
+}
+
 hal_status_t hal_uart_write_char(hal_uart_t uart, char c) {
   volatile UARTx_Reg_Typedef *usart = _get_usart(uart);
   if (!usart)
@@ -307,6 +386,10 @@ static _uart_dma_params_t _get_uart_dma_params(hal_uart_t uart, int is_tx) {
  */
 static uint8_t _uart_dma_initialized[6] = {0};
 
+/** Configured circular RX-buffer length per UART (UART1=0, UART2=1, UART6=2);
+ *  0 until hal_uart_init_dma_rx() runs. Used to turn NDTR into a write index. */
+static uint16_t _uart_rx_dma_len[3] = {0};
+
 hal_status_t hal_uart_write_dma(hal_uart_t uart, const uint8_t *data,
                                 uint16_t length) {
   if (!data || length == 0)
@@ -386,6 +469,23 @@ hal_status_t hal_uart_init_dma_rx(hal_uart_t uart, uint8_t *buffer,
 
   int idx = (uart == HAL_UART_1) ? 1 : (uart == HAL_UART_2) ? 3 : 5;
   _uart_dma_initialized[idx] = 1;
+  _uart_rx_dma_len[_uart_idx(uart)] = length;
+  return HAL_OK;
+}
+
+hal_status_t hal_uart_dma_rx_index(hal_uart_t uart, uint16_t *out_index) {
+  if (!out_index)
+    return HAL_ERR_INVALID_ARG;
+  _uart_dma_params_t p = _get_uart_dma_params(uart, 0);
+  uint16_t len = _uart_rx_dma_len[_uart_idx(uart)];
+  if (!p.controller || len == 0)
+    return HAL_ERR_INVALID_ARG; /* RX DMA not configured for this UART */
+
+  /* NDTR counts down from `len` to 0 as the DMA fills the circular buffer, so
+   * the next-write index is len - NDTR. Reading the correct stream's NDTR is
+   * the whole point — callers must not guess the stream themselves. */
+  uint16_t ndtr = (uint16_t)(p.controller->STREAM[p.stream].NDTR & 0xFFFFu);
+  *out_index = (uint16_t)(len - ndtr);
   return HAL_OK;
 }
 

--- a/tests/arch/cortex-m4/test_uart_protocol.c
+++ b/tests/arch/cortex-m4/test_uart_protocol.c
@@ -140,6 +140,29 @@ void test_hal_uart_available_after_init_is_false(void) {
   init_test_uart(115200);
   TEST_ASSERT_FALSE(hal_uart_available(TEST_UART));
 }
+
+/* -------------------- idle-line callback surface -------------------- */
+
+static void _idle_noop_cb(void) {}
+
+void test_hal_uart_attach_idle_rejects_null_cb(void) {
+  TEST_ASSERT_EQUAL_UINT32(
+      (uint32_t)HAL_ERR_INVALID_ARG,
+      (uint32_t)hal_uart_attach_idle_callback(TEST_UART, NULL));
+}
+
+void test_hal_uart_attach_idle_sets_and_clears_idleie(void) {
+  init_test_uart(115200);
+  volatile UARTx_Reg_Typedef *u = GET_USARTx_BASE(1);
+  TEST_ASSERT_EQUAL_UINT32(
+      (uint32_t)HAL_OK,
+      (uint32_t)hal_uart_attach_idle_callback(TEST_UART, _idle_noop_cb));
+  TEST_ASSERT_TRUE((u->CR1 & USART_CR1_IDLEIE) != 0u);
+  TEST_ASSERT_EQUAL_UINT32(
+      (uint32_t)HAL_OK, (uint32_t)hal_uart_detach_idle_callback(TEST_UART));
+  TEST_ASSERT_TRUE((u->CR1 & USART_CR1_IDLEIE) == 0u);
+}
+
 /* PROGMEM slot for each case name on AVR; no-op elsewhere. */
 NAVTEST_CASE_DECL(test_uart_baudrate_9600);
 NAVTEST_CASE_DECL(test_uart_baudrate_115200);
@@ -153,6 +176,8 @@ NAVTEST_CASE_DECL(test_hal_uart_write_float_returns_ok);
 NAVTEST_CASE_DECL(test_hal_uart_write_string_returns_ok);
 NAVTEST_CASE_DECL(test_hal_uart_print_generic_dispatch);
 NAVTEST_CASE_DECL(test_hal_uart_available_after_init_is_false);
+NAVTEST_CASE_DECL(test_hal_uart_attach_idle_rejects_null_cb);
+NAVTEST_CASE_DECL(test_hal_uart_attach_idle_sets_and_clears_idleie);
 
 
 static const navtest_case_t uart_protocol_cases[] = {
@@ -168,6 +193,8 @@ static const navtest_case_t uart_protocol_cases[] = {
     NAVTEST_CASE(test_hal_uart_write_string_returns_ok),
     NAVTEST_CASE(test_hal_uart_print_generic_dispatch),
     NAVTEST_CASE(test_hal_uart_available_after_init_is_false),
+    NAVTEST_CASE(test_hal_uart_attach_idle_rejects_null_cb),
+    NAVTEST_CASE(test_hal_uart_attach_idle_sets_and_clears_idleie),
 };
 
 const navtest_suite_t test_uart_protocol_suite = {

--- a/tests/arch/cortex-m4/test_uart_protocol.h
+++ b/tests/arch/cortex-m4/test_uart_protocol.h
@@ -50,6 +50,10 @@ void test_hal_uart_print_generic_dispatch(void);
 /* read surface */
 void test_hal_uart_available_after_init_is_false(void);
 
+/* idle-line callback surface */
+void test_hal_uart_attach_idle_rejects_null_cb(void);
+void test_hal_uart_attach_idle_sets_and_clears_idleie(void);
+
 extern const navtest_suite_t test_uart_protocol_suite;
 
 


### PR DESCRIPTION
Adds event-driven, register-free DMA UART reception for byte-oriented RC protocols (iBUS/SBUS).

## API (cortex-m4 / STM32F4)
- `hal_uart_attach_idle_callback(uart, cb)` / `hal_uart_detach_idle_callback(uart)` — USART IDLE-line interrupt → user callback, demuxed off the existing `USARTx_IRQHandler` dispatch (no vector-table change), IDLE cleared via SR-then-DR read, NVIC line at `HAL_IRQ_PRIORITY_DEFAULT` (maskable) so the callback may call RTOS `*_from_isr`.
- `hal_uart_dma_rx_index(uart, *out)` — circular write index (`length - NDTR`) read from the correct RX stream resolved by `_get_uart_dma_params()`, so consumers stop poking DMA registers / guessing the stream.

## Why
Lets the consumer (vayu's iBus task) block on end-of-frame instead of polling at 500 Hz and reading the wrong DMA stream's NDTR directly.

## Tests
On-target null-arg contract + IDLEIE set/clear assertions; host + ARM builds green.

## Version
0.2.0 → 0.2.1 (purely additive, ABI-compatible).