### PR TITLE
feat(interrupt): hal_cpu_idle() WFI primitive (0.2.2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 # disagree: bumping one without the other is a release-process bug, not
 # something we want to silently build. This check runs on every configure,
 # including when NavHAL is consumed as a submodule.
-set(NAVHAL_VERSION 0.2.1) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
+set(NAVHAL_VERSION 0.2.2) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/include/navhal.h" _navhal_h)
 string(REGEX MATCH "#define[ \t]+VERSION_MAJOR[ \t]+([0-9]+)" _ "${_navhal_h}")
 set(_navhal_h_major "${CMAKE_MATCH_1}")

--- a/include/navhal.h
+++ b/include/navhal.h
@@ -36,8 +36,8 @@
 /* Release version (SemVer) — the version of this NavHAL distribution. */
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 2
-#define VERSION_PATCH 1
-#define VERSION "0.2.1"
+#define VERSION_PATCH 2
+#define VERSION "0.2.2"
 
 /**
  * @brief NavHAL public-API contract version.

--- a/include/port/cortex-m4/navhal_port_interrupt.h
+++ b/include/port/cortex-m4/navhal_port_interrupt.h
@@ -149,6 +149,18 @@ uint32_t hal_interrupt_disable_global(void);
  */
 void hal_interrupt_clear_all_pending(void);
 
+/**
+ * @brief Put the CPU to sleep until the next interrupt (WFI).
+ *
+ * Executes a Wait-For-Interrupt: the core stops the CPU clock and resumes on
+ * the next wakeup event (any enabled interrupt, including SysTick), cutting
+ * idle power instead of spinning. A wakeup event already pending at entry makes
+ * WFI return immediately, so it never deadlocks. Intended for an RTOS idle
+ * task — call once per idle pass so the core sleeps between interrupts rather
+ * than busy-looping.
+ */
+void hal_cpu_idle(void);
+
 /* Deprecated pre-standardization interrupt names — retained as a backward-compat alias. */
 #include "compat/interrupt_compat.h"
 

--- a/src/arch/armv7e-m/interrupt/interrupt.c
+++ b/src/arch/armv7e-m/interrupt/interrupt.c
@@ -220,6 +220,14 @@ uint32_t hal_interrupt_disable_global(void) {
   return state;
 }
 
+void hal_cpu_idle(void) {
+  /* DSB before WFI so prior memory writes (e.g. clearing a wake flag) retire
+   * first; WFI sleeps the core until a wakeup event. A pending wakeup event at
+   * entry returns immediately, so this cannot deadlock. */
+  __asm volatile("dsb 0xf" : : : "memory");
+  __asm volatile("wfi" : : : "memory");
+}
+
 void hal_interrupt_clear_all_pending(void) {
   /* STM32F401RE wires IRQs 0..81 (NVIC ICPR words 0..2). Writing past
    * that range is a no-op on real silicon but produces "unhandled

--- a/tests/arch/cortex-m4/test_interrupt.c
+++ b/tests/arch/cortex-m4/test_interrupt.c
@@ -24,6 +24,7 @@
 #include "navhal_port_interrupt.h"
 #include "family/interrupt_reg.h"
 #include "navtest/navtest.h"
+#include "navtest/navtest_pil.h"
 #include "test_interrupt.h"
 
 #include <stdbool.h>
@@ -125,6 +126,29 @@ void test_hal_interrupt_clear_all_pending_zeros_icpr(void) {
   TEST_ASSERT_EQUAL_UINT32(0u, NVIC->ISPR[1]);
 }
 
+void test_hal_cpu_idle_returns_on_pending_irq(void) {
+  /* A wakeup event already pending at WFI entry must make hal_cpu_idle()
+   * return immediately rather than halt — so this exercises the no-deadlock
+   * guarantee. Pend an *enabled* IRQ (a valid wake source) while PRIMASK masks
+   * it (so the handler doesn't actually run), call hal_cpu_idle(), and clear it
+   * before unmasking. Reaching the assert proves WFI returned.
+   *
+   * WFI modelling under Renode can stall the run, so validate on HIL only. */
+  NAVTEST_SKIP_ON_PIL();
+
+  hal_interrupt_clear_pending(TEST_IRQ);
+  hal_interrupt_enable(TEST_IRQ);
+  uint32_t pm = hal_interrupt_disable_global();
+  NVIC->ISPR[iser_word(TEST_IRQ)] = iser_bit(TEST_IRQ); /* pend a wake event */
+
+  hal_cpu_idle(); /* must return (pending event => no halt) */
+
+  hal_interrupt_clear_pending(TEST_IRQ); /* clear before unmasking */
+  hal_interrupt_disable(TEST_IRQ);
+  hal_interrupt_enable_global(pm);
+  TEST_ASSERT_TRUE(1);
+}
+
 /* -------------------- Error-path tests -------------------- */
 
 void test_hal_interrupt_enable_rejects_negative_irq(void) {
@@ -219,6 +243,7 @@ NAVTEST_CASE_DECL(test_hal_interrupt_attach_then_dispatch_runs_callback);
 NAVTEST_CASE_DECL(test_hal_interrupt_detach_clears_callback);
 NAVTEST_CASE_DECL(test_hal_interrupt_disable_then_restore_global);
 NAVTEST_CASE_DECL(test_hal_interrupt_clear_all_pending_zeros_icpr);
+NAVTEST_CASE_DECL(test_hal_cpu_idle_returns_on_pending_irq);
 NAVTEST_CASE_DECL(test_hal_interrupt_enable_rejects_negative_irq);
 NAVTEST_CASE_DECL(test_hal_interrupt_disable_rejects_negative_irq);
 NAVTEST_CASE_DECL(test_hal_interrupt_clear_pending_rejects_negative_irq);
@@ -237,6 +262,7 @@ static const navtest_case_t interrupt_cases[] = {
     NAVTEST_CASE(test_hal_interrupt_detach_clears_callback),
     NAVTEST_CASE(test_hal_interrupt_disable_then_restore_global),
     NAVTEST_CASE(test_hal_interrupt_clear_all_pending_zeros_icpr),
+    NAVTEST_CASE(test_hal_cpu_idle_returns_on_pending_irq),
     /* error paths */
     NAVTEST_CASE(test_hal_interrupt_enable_rejects_negative_irq),
     NAVTEST_CASE(test_hal_interrupt_disable_rejects_negative_irq),

--- a/tests/arch/cortex-m4/test_interrupt.h
+++ b/tests/arch/cortex-m4/test_interrupt.h
@@ -37,6 +37,7 @@ void test_hal_interrupt_is_pending_after_set(void);
 void test_hal_interrupt_attach_then_dispatch_runs_callback(void);
 void test_hal_interrupt_detach_clears_callback(void);
 void test_hal_interrupt_disable_then_restore_global(void);
+void test_hal_cpu_idle_returns_on_pending_irq(void);
 void test_hal_interrupt_clear_all_pending_zeros_icpr(void);
 
 /* error paths */


### PR DESCRIPTION
Adds a Cortex-M4 Wait-For-Interrupt primitive so an RTOS idle task can sleep the core between interrupts instead of busy-spinning at full clock.

## API
- `hal_cpu_idle(void)` — DSB then WFI; a wakeup event already pending at entry returns immediately, so it never deadlocks. Declared in the cortex-m4 port header, implemented in the arch interrupt module (next to the global-IRQ asm). cortex-m4 only; AVR untouched.

## Why
vaios's idle task busy-spun (log-flush + dead-task GC) with no WFI, so the core ran at full 84 MHz through all idle time — wasted power and constant ENTER_CRITICAL churn jittering every ISR. This lets the idle task sleep the core each pass.

## Tests
On-target (HIL; `NAVTEST_SKIP_ON_PIL` since WFI modelling can stall Renode): pends a masked enabled IRQ and asserts `hal_cpu_idle()` returns. Host + ARM builds green.

## Version
0.2.1 -> 0.2.2 (purely additive, ABI-compatible).