### PR TITLE
build(linker): give .bss a RAM load address (v0.2.3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 # disagree: bumping one without the other is a release-process bug, not
 # something we want to silently build. This check runs on every configure,
 # including when NavHAL is consumed as a submodule.
-set(NAVHAL_VERSION 0.2.2) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
+set(NAVHAL_VERSION 0.2.3) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/include/navhal.h" _navhal_h)
 string(REGEX MATCH "#define[ \t]+VERSION_MAJOR[ \t]+([0-9]+)" _ "${_navhal_h}")
 set(_navhal_h_major "${CMAKE_MATCH_1}")

--- a/include/navhal.h
+++ b/include/navhal.h
@@ -36,8 +36,8 @@
 /* Release version (SemVer) — the version of this NavHAL distribution. */
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 2
-#define VERSION_PATCH 2
-#define VERSION "0.2.2"
+#define VERSION_PATCH 3
+#define VERSION "0.2.3"
 
 /**
  * @brief NavHAL public-API contract version.

--- a/src/board/nucleo_f401re/linker.ld
+++ b/src/board/nucleo_f401re/linker.ld
@@ -45,7 +45,7 @@ SECTIONS {
     _ebss = .;
     __bss_end__ = .;
     _heap_start = .;
-  } > RAM
+  } > RAM AT > RAM
   _heap_end   = ORIGIN(RAM) + LENGTH(RAM);
   _sidata = LOADADDR(.data);
   _estack = ORIGIN(RAM) + LENGTH(RAM);

--- a/tests/arch/cortex-m4/linker.ld
+++ b/tests/arch/cortex-m4/linker.ld
@@ -35,7 +35,7 @@ SECTIONS {
     *(.bss*)
     *(COMMON)
     _ebss = .;
-  } > RAM
+  } > RAM AT > RAM
 
   _sidata = LOADADDR(.data);
   _estack = ORIGIN(RAM) + LENGTH(RAM);


### PR DESCRIPTION
## What

Give `.bss` its own RAM load address (`} > RAM AT > RAM`) in both the
`nucleo_f401re` board linker script and the `cortex-m4` test linker
script, and bump the release version to **0.2.3**.

## Why

The `.data`/`.bss` `PT_LOAD` segment had its load address (LMA) in flash
(`_sidata`) with `memsz > filesz`: `.bss` inherited a flash LMA flowing
from `.data`'s `AT()`, and `ld` merged both into one flash-addressed
segment. QEMU's `-kernel` ELF loader zero-fills `(memsz - filesz)` bytes
at the segment `paddr`, so it wrote the `.bss` tail into read-only flash
and the flash region rejected every word:

```
Invalid write at addr 0x5A90, size 4, region 'STM32F405.flash', reason: rejected
```

(Surfaced when running the VaiOS IPC test on the `netduinoplus2` QEMU model.)

## Fix

`AT > RAM` gives `.bss` a RAM LMA, so `ld` emits it as a separate segment
and `.data`'s segment ends with `memsz == filesz`:

```
LOAD  vaddr 0x20000000  paddr 0x08005a78  filesz 0x18  memsz 0x18   RW   ← .data
LOAD  vaddr 0x20000018  paddr 0x20000018  filesz 0x0   memsz 0x3f0  RW   ← .bss → RAM
```

Hardware behavior is unchanged: `_sidata` still points at flash, startup
copies `.data` and zeroes `.bss` in RAM as before, and a flasher only
programs `filesz` bytes. The change only affects how QEMU's loader treats
the image.

## Verification (run locally)

| Gate | Result |
|---|---|
| Semver gate (`0.2.2 → 0.2.3`) | ✅ |
| Host tests | 24/0 |
| Host tests ASan+UBSan | 24/0 |
| Build on-target ELF | ✅ (segment split confirmed) |
| Capability contract | 12/0 |
| Sample matrix (cortex-m) | 28/0 |
| Sample matrix (AVR) | 12/0 |
| PIL Renode `nucleo_f401re` | 147/0 |
| PIL simavr `atmega328p` | 36/0 |
| License headers | 214/214 |
| Doxygen strict (`WARN_AS_ERROR`) | no warnings |
| Commit lint | 2/2 |