### PR TITLE
feat(v_fs): directory listing + stat primitives; restore hal_i2c_deinit (0.2.4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 # disagree: bumping one without the other is a release-process bug, not
 # something we want to silently build. This check runs on every configure,
 # including when NavHAL is consumed as a submodule.
-set(NAVHAL_VERSION 0.2.3) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
+set(NAVHAL_VERSION 0.2.4) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/include/navhal.h" _navhal_h)
 string(REGEX MATCH "#define[ \t]+VERSION_MAJOR[ \t]+([0-9]+)" _ "${_navhal_h}")
 set(_navhal_h_major "${CMAKE_MATCH_1}")

--- a/include/common/hal_i2c.h
+++ b/include/common/hal_i2c.h
@@ -83,6 +83,20 @@ typedef struct {
 hal_status_t hal_i2c_init(hal_i2c_bus_t bus, const hal_i2c_config_t *config);
 
 /**
+ * @brief De-initialize an I²C bus: software-reset the peripheral and clear its
+ *        init-status bit.
+ *
+ * hal_i2c_init() early-returns ::HAL_ERR_NOT_INITIALIZED on an already-init bus
+ * and so skips its SWRST. Recovery paths (bus stuck BUSY, DMA fail) call this
+ * first to clear the init bit and reset the peripheral, so the following
+ * hal_i2c_init() performs the full reset + reconfigure.
+ *
+ * @param bus I²C bus instance.
+ * @return ::HAL_OK.
+ */
+hal_status_t hal_i2c_deinit(hal_i2c_bus_t bus);
+
+/**
  * @brief Write a byte buffer to an I²C device (blocking).
  * @param bus      I²C bus instance.
  * @param dev_addr 7-bit device address.

--- a/include/navhal.h
+++ b/include/navhal.h
@@ -36,7 +36,7 @@
 /* Release version (SemVer) — the version of this NavHAL distribution. */
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 2
-#define VERSION_PATCH 3
+#define VERSION_PATCH 4
 #define VERSION "0.2.3"
 
 /**

--- a/include/utils/v_fs.h
+++ b/include/utils/v_fs.h
@@ -51,6 +51,25 @@ extern "C" {
 #define V_SEEK_END 2
 
 typedef int v_fd_t;
+typedef int v_dir_t;
+
+/* FatFS short (8.3) names: 12 chars + NUL (FF_USE_LFN = 0). */
+#define V_NAME_MAX 13
+
+/** @brief One directory entry returned by v_readdir(). */
+typedef struct {
+  char name[V_NAME_MAX]; /**< file/dir name (8.3) */
+  uint32_t size;         /**< file size in bytes (0 for directories) */
+  uint8_t is_dir;        /**< 1 if this entry is a directory */
+} v_dirent_t;
+
+/** @brief File/directory status returned by v_stat(). */
+typedef struct {
+  uint32_t size;  /**< file size in bytes (0 for directories) */
+  uint32_t mtime; /**< FatFS packed modified time: (fdate << 16) | ftime */
+  uint8_t is_dir; /**< 1 if the path is a directory */
+  uint8_t exists; /**< 1 if the path exists (else the rest is unset) */
+} v_stat_t;
 
 /**
  * @brief Initialize the filesystem and mount the default drive.
@@ -130,6 +149,36 @@ int v_sync(v_fd_t fd);
  * @return 0 on success, negative FatFS error code otherwise.
  */
 int v_preallocate(const char *path, uint32_t size);
+
+/**
+ * @brief Get the status of a file or directory.
+ * @param path Path (with drive prefix, e.g. "0:log.dat").
+ * @param st   Filled on return; st->exists distinguishes "absent" from "error".
+ * @return 0 on success (path exists), negative FatFS error code otherwise
+ *         (st->exists set to 0).
+ */
+int v_stat(const char *path, v_stat_t *st);
+
+/**
+ * @brief Open a directory for iteration.
+ * @param path Directory path (e.g. "0:" or "0:logs").
+ * @return A directory handle (>= 0) on success, negative error code otherwise.
+ */
+v_dir_t v_opendir(const char *path);
+
+/**
+ * @brief Read the next entry from an open directory.
+ * @param d   Directory handle from v_opendir().
+ * @param ent Filled with the next entry on return.
+ * @return 1 if an entry was read, 0 at end of directory, negative on error.
+ */
+int v_readdir(v_dir_t d, v_dirent_t *ent);
+
+/**
+ * @brief Close a directory handle.
+ * @return 0 on success, negative error code otherwise.
+ */
+int v_closedir(v_dir_t d);
 
 
 #ifdef __cplusplus

--- a/src/utils/v_fs.c
+++ b/src/utils/v_fs.c
@@ -24,10 +24,13 @@
 #include "fatfs/ff.h"
 
 #define MAX_OPEN_FILES 4
+#define MAX_OPEN_DIRS 2
 
 static FATFS fs_obj;
 static FIL open_files[MAX_OPEN_FILES];
 static uint8_t file_in_use[MAX_OPEN_FILES] = {0};
+static DIR dir_objs[MAX_OPEN_DIRS];
+static uint8_t dir_in_use[MAX_OPEN_DIRS] = {0};
 
 int v_fs_init(void) {
   FRESULT res = f_mount(&fs_obj, "0:", 1);
@@ -186,4 +189,67 @@ int v_preallocate(const char *path, uint32_t size) {
   f_sync(&fil);
   f_close(&fil);
   return 0;
+}
+
+int v_stat(const char *path, v_stat_t *st) {
+  if (st == NULL)
+    return -1;
+  FILINFO fno;
+  FRESULT res = f_stat(path, &fno);
+  if (res != FR_OK) {
+    st->exists = 0;
+    return -(int)res;
+  }
+  st->exists = 1;
+  st->size = (uint32_t)fno.fsize;
+  st->is_dir = (fno.fattrib & AM_DIR) ? 1 : 0;
+  st->mtime = ((uint32_t)fno.fdate << 16) | (uint32_t)fno.ftime;
+  return 0;
+}
+
+v_dir_t v_opendir(const char *path) {
+  int d = -1;
+  for (int i = 0; i < MAX_OPEN_DIRS; i++) {
+    if (!dir_in_use[i]) {
+      d = i;
+      break;
+    }
+  }
+  if (d == -1)
+    return -1;
+
+  FRESULT res = f_opendir(&dir_objs[d], path);
+  if (res != FR_OK)
+    return -(int)res;
+
+  dir_in_use[d] = 1;
+  return d;
+}
+
+int v_readdir(v_dir_t d, v_dirent_t *ent) {
+  if (d < 0 || d >= MAX_OPEN_DIRS || !dir_in_use[d] || ent == NULL)
+    return -1;
+
+  FILINFO fno;
+  FRESULT res = f_readdir(&dir_objs[d], &fno);
+  if (res != FR_OK)
+    return -(int)res;
+  if (fno.fname[0] == 0)
+    return 0; /* end of directory */
+
+  int i = 0;
+  for (; i < V_NAME_MAX - 1 && fno.fname[i] != 0; i++)
+    ent->name[i] = (char)fno.fname[i];
+  ent->name[i] = '\0';
+  ent->size = (uint32_t)fno.fsize;
+  ent->is_dir = (fno.fattrib & AM_DIR) ? 1 : 0;
+  return 1;
+}
+
+int v_closedir(v_dir_t d) {
+  if (d < 0 || d >= MAX_OPEN_DIRS || !dir_in_use[d])
+    return -1;
+  FRESULT res = f_closedir(&dir_objs[d]);
+  dir_in_use[d] = 0;
+  return (res == FR_OK) ? 0 : -(int)res;
 }

--- a/src/vendor/stm32/i2c/i2c.c
+++ b/src/vendor/stm32/i2c/i2c.c
@@ -211,6 +211,20 @@ hal_status_t hal_i2c_init(hal_i2c_bus_t bus, const hal_i2c_config_t *config) {
   }
 }
 
+hal_status_t hal_i2c_deinit(hal_i2c_bus_t bus) {
+  I2C_Reg_Typedef *I2C = I2C_GET_BASE(bus);
+
+  // Disable the peripheral and assert/release the software reset so the next
+  // hal_i2c_init() reconfigures from a clean state.
+  I2C->CR1 &= ~I2C_CR1_PE_MASK;
+  I2C->CR1 |= I2C_CR1_SWRST_MASK;
+  I2C->CR1 &= ~I2C_CR1_SWRST_MASK;
+
+  // Clear this bus's init-status bit (mirrors the per-bus bits set in init).
+  __i2c_init_status &= (uint8_t)~(1u << bus);
+  return HAL_OK;
+}
+
 static int _wait_flag(volatile uint32_t *reg, uint32_t mask) {
   int timeout = TIMEOUT;
   while (((*reg & mask) == 0) && --timeout) {


### PR DESCRIPTION
## Summary

Adds the POSIX-like VFS directory/stat primitives a downstream filesystem-browse
feature needs, and restores a peripheral-recovery helper that downstream FC code
already relies on. Patch release **0.2.4**.

## Changes

- **`v_fs`** (`src/utils/v_fs.c`, `include/utils/v_fs.h`):
  - `v_stat(path, &st)` — `f_stat` → size / is_dir / packed mtime; `st->exists`
    distinguishes absent from error.
  - `v_opendir` / `v_readdir` / `v_closedir` — `f_opendir`/`f_readdir`/`f_closedir`
    over a small static `DIR` pool (`MAX_OPEN_DIRS=2`), mirroring the `open_files`
    pool. `v_readdir` returns 1/0/<0 (entry / end-of-dir / error) and yields 8.3
    names (`FF_USE_LFN=0` → `V_NAME_MAX=13`), size and `is_dir`. FatFS already
    compiles these in (`FF_FS_MINIMIZE=0`). Callers must serialise SD access.

- **`hal_i2c_deinit`** (`src/vendor/stm32/i2c/i2c.c`, `include/common/hal_i2c.h`):
  disable the peripheral, pulse `CR1.SWRST`, and clear the bus's
  `__i2c_init_status` bit so the next `hal_i2c_init()` runs a full reset +
  reconfigure instead of early-returning `HAL_ERR_NOT_INITIALIZED`. Bus-recovery
  paths (stuck BUSY / DMA fail) rely on this; it had been used downstream but was
  never committed across a version bump.

- **Version** bumped 0.2.3 → 0.2.4 (`CMakeLists.txt` + `include/navhal.h`, kept in
  sync per the CMake assertion).

## Testing

`v_fs` is FatFS-over-SDIO, so it isn't exercisable on the host suite or Renode
(no SD model); it is **compile-verified against the real FatFS headers**, and
functionally verified end-to-end in the downstream SITL (host VFS over a real
directory). Pre-commit host tests + kconfig pass.