### PR TITLE
fix(sdio): clear only data flags in the data-completion ISR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 # disagree: bumping one without the other is a release-process bug, not
 # something we want to silently build. This check runs on every configure,
 # including when NavHAL is consumed as a submodule.
-set(NAVHAL_VERSION 0.2.4) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
+set(NAVHAL_VERSION 0.2.5) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/include/navhal.h" _navhal_h)
 string(REGEX MATCH "#define[ \t]+VERSION_MAJOR[ \t]+([0-9]+)" _ "${_navhal_h}")
 set(_navhal_h_major "${CMAKE_MATCH_1}")

--- a/include/navhal.h
+++ b/include/navhal.h
@@ -36,7 +36,7 @@
 /* Release version (SemVer) — the version of this NavHAL distribution. */
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 2
-#define VERSION_PATCH 4
+#define VERSION_PATCH 5
 #define VERSION "0.2.3"
 
 /**

--- a/src/vendor/stm32/family/stm32f4/include/family/sdio_reg.h
+++ b/src/vendor/stm32/family/stm32f4/include/family/sdio_reg.h
@@ -147,6 +147,28 @@ typedef struct {
 #define SDIO_ICR_DBCKENDC (1 << 10)
 #define SDIO_ICR_SDIOITC (1 << 22)
 
+/* Grouped ICR clear masks.
+ *
+ * The SDIO status flags split into two families: COMMAND-path flags, set around a
+ * CPSM command (CMDREND/CMDSENT/CTIMEOUT/CCRCFAIL), and DATA-path flags, set around
+ * a DPSM transfer (DATAEND/DBCKEND/DCRCFAIL/DTIMEOUT/RXOVERR/TXUNDERR/STBITERR).
+ *
+ * These two families must be cleared INDEPENDENTLY. The data-completion ISR clears
+ * its transfer with SDIO_ICR_DATA_FLAGS and must NEVER touch SDIO_ICR_CMD_FLAGS:
+ * the synchronous send_command() poll spins waiting on CMDREND, and for a fast
+ * single-block read the data phase can finish (firing the ISR) before a preempted
+ * poll has observed CMDREND. A blanket ICR = 0xFFFFFFFF in the ISR clears CMDREND
+ * out from under that poll, which then times out on a command that actually
+ * succeeded — a false HAL_SDIO_TIMEOUT that surfaces as FR_DISK_ERR and stalls the
+ * transfer. Keeping the two masks disjoint is the invariant the SDIO tests pin. */
+#define SDIO_ICR_DATA_FLAGS                                                    \
+  (SDIO_ICR_DCRCFAILC | SDIO_ICR_DTIMEOUTC | SDIO_ICR_TXUNDERRC |             \
+   SDIO_ICR_RXOVERRC | SDIO_ICR_DATAENDC | SDIO_ICR_STBITERRC |              \
+   SDIO_ICR_DBCKENDC)
+#define SDIO_ICR_CMD_FLAGS                                                     \
+  (SDIO_ICR_CCRCFAILC | SDIO_ICR_CTIMEOUTC | SDIO_ICR_CMDRENDC |              \
+   SDIO_ICR_CMDSENTC)
+
 /* MASK Register */
 #define SDIO_MASK_CCRCFAILIE (1 << 0)
 #define SDIO_MASK_DCRCFAILIE (1 << 1)

--- a/src/vendor/stm32/sdio/sdio.c
+++ b/src/vendor/stm32/sdio/sdio.c
@@ -39,7 +39,10 @@ static volatile uint8_t sd_busy = 0;
 static volatile uint8_t dma_done = 0;
 static volatile uint8_t sdio_done = 0;
 static volatile uint8_t is_multi_block = 0;
+static volatile uint8_t sd_last_was_write = 0; /* gate the post-op card-ready wait */
 static hal_sdio_error_t sd_last_error = HAL_SDIO_OK;
+static uint32_t sd_csd[4] = {0}; /* CSD cached during init (STANDBY window) */
+static uint8_t sd_csd_valid = 0;
 
 /* ------------------------------------------------------------- */
 /* INIT */
@@ -258,6 +261,18 @@ hal_sdio_error_t hal_sdio_card_init(void) {
   hal_sdio_send_command(SD_CMD_SEND_REL_ADDR, 0, 1);
   sd_rca = hal_sdio_get_response(1) & 0xFFFF0000;
 
+  /* Read the CSD NOW, while the card is in STANDBY (after CMD3, before the CMD7
+   * select moves it to TRANSFER). CMD9 (SEND_CSD) is only legal in STANDBY; issuing
+   * it after selection returns garbage, which is why hal_sdio_get_sector_count()
+   * reported 0 sectors (and f_mkfs aborted with FR_MKFS_ABORTED). Cache it here. */
+  if (hal_sdio_send_command(9, sd_rca, 3) == HAL_SDIO_OK) {
+    sd_csd[0] = SDIO->RESP1;
+    sd_csd[1] = SDIO->RESP2;
+    sd_csd[2] = SDIO->RESP3;
+    sd_csd[3] = SDIO->RESP4;
+    sd_csd_valid = 1;
+  }
+
   hal_sdio_send_command(SD_CMD_SELECT_DESELECT_CARD, sd_rca, 1);
   if (!card_is_sdhc)
     hal_sdio_send_command(SD_CMD_SET_BLOCKLEN, 512, 1);
@@ -436,20 +451,14 @@ hal_sdio_error_t hal_sdio_write_block(uint32_t addr, const uint8_t *buf) {
 }
 
 uint32_t hal_sdio_get_sector_count(void) {
-  uint32_t csd[4];
-
-  /* Send CMD9 (SEND_CSD) to get card capacity. Long response (R2) */
-  if (hal_sdio_send_command(9, sd_rca, 3) != HAL_SDIO_OK) {
+  /* Use the CSD cached at init (STANDBY window). Re-issuing CMD9 here would fail:
+   * the card is in TRANSFER state now and SEND_CSD is only legal in STANDBY. */
+  if (!sd_csd_valid) {
     return 0;
   }
+  const uint32_t *csd = sd_csd;
 
-  /* RESP1 contains bits [127:96], RESP2 [95:64], RESP3 [63:32], RESP4 [31:0]
-   */
-  csd[0] = SDIO->RESP1;
-  csd[1] = SDIO->RESP2;
-  csd[2] = SDIO->RESP3;
-  csd[3] = SDIO->RESP4;
-
+  /* RESP1 contains bits [127:96], RESP2 [95:64], RESP3 [63:32], RESP4 [31:0] */
   /* CSD Structure depends on CSD_STRUCTURE field [127:126] */
   uint8_t csd_struct = (csd[0] >> 30) & 0x3;
 
@@ -486,6 +495,7 @@ static void _sdio_dma_tx_irq_handler(void);
 hal_sdio_error_t hal_sdio_read_block_async(uint32_t addr, uint8_t *buf) {
   if (sd_busy)
     return HAL_SDIO_BUSY;
+  sd_last_was_write = 0;
 
   if (!card_is_sdhc)
     addr *= 512;
@@ -520,27 +530,34 @@ hal_sdio_error_t hal_sdio_read_block_async(uint32_t addr, uint8_t *buf) {
 
   SDIO->DTIMER = 0xFFFFFFFF;
   SDIO->DLEN = 512;
+
+  /* Arm the completion rendezvous + SDIO IRQs BEFORE the trigger. The DMA
+   * stream IRQ is already enabled, so once hal_dma_start()/the command runs a
+   * completion can fire immediately; if dma_done/sdio_done/sd_busy were set
+   * afterwards, that early IRQ is erased and sd_busy stays 1 forever. */
+  dma_done = 0;
+  sdio_done = 0;
+  is_multi_block = 0;
+  sd_last_error = HAL_SDIO_OK;
+  sd_busy = 1;
+  SDIO->MASK |= SDIO_MASK_DATAENDIE | SDIO_MASK_DBCKENDIE |
+                SDIO_MASK_DCRCFAILIE | SDIO_MASK_DTIMEOUTIE |
+                SDIO_MASK_RXOVERRIE | SDIO_MASK_STBITERRIE;
+
   SDIO->DCTRL = (9 << SDIO_DCTRL_DBLOCKSIZE_Pos) | SDIO_DCTRL_DTDIR |
                 SDIO_DCTRL_DMAEN | SDIO_DCTRL_DTEN;
 
   hal_dma_start((const hal_dma_config_t *)&dma2_stream3_cfg);
 
   if (hal_sdio_send_command(SD_CMD_READ_SINGLE_BLOCK, addr, 1)) {
+    SDIO->MASK &= ~(SDIO_MASK_DATAENDIE | SDIO_MASK_DBCKENDIE |
+                    SDIO_MASK_DCRCFAILIE | SDIO_MASK_DTIMEOUTIE |
+                    SDIO_MASK_RXOVERRIE | SDIO_MASK_STBITERRIE);
     SDIO->DCTRL = 0;
+    sd_busy = 0;
     hal_dma_stop((const hal_dma_config_t *)&dma2_stream3_cfg);
     return HAL_SDIO_ERROR;
   }
-
-  sd_busy = 1;
-  dma_done = 0;
-  sdio_done = 0;
-  is_multi_block = 0;
-  sd_last_error = HAL_SDIO_OK;
-
-  /* Enable SDIO interrupts: DATAEND, DBCKEND, and error flags */
-  SDIO->MASK |= SDIO_MASK_DATAENDIE | SDIO_MASK_DBCKENDIE |
-                SDIO_MASK_DCRCFAILIE | SDIO_MASK_DTIMEOUTIE |
-                SDIO_MASK_RXOVERRIE;
 
   return HAL_SDIO_PENDING;
 }
@@ -548,6 +565,7 @@ hal_sdio_error_t hal_sdio_read_block_async(uint32_t addr, uint8_t *buf) {
 hal_sdio_error_t hal_sdio_write_block_async(uint32_t addr, const uint8_t *buf) {
   if (sd_busy)
     return HAL_SDIO_BUSY;
+  sd_last_was_write = 1;
 
   if (!card_is_sdhc)
     addr *= 512;
@@ -582,31 +600,40 @@ hal_sdio_error_t hal_sdio_write_block_async(uint32_t addr, const uint8_t *buf) {
 
   SDIO->DTIMER = 0xFFFFFFFF;
   SDIO->DLEN = 512;
+
+  /* Arm rendezvous + IRQs BEFORE the trigger (see read_block_async). is_multi_block
+   * MUST be reset here too, else a stale 1 from a prior errored multi-block op makes
+   * wait_sync send a spurious CMD12 STOP after this write and report ERROR. */
+  dma_done = 0;
+  sdio_done = 0;
+  is_multi_block = 0;
+  sd_last_error = HAL_SDIO_OK;
+  sd_busy = 1;
+  SDIO->MASK |= SDIO_MASK_DATAENDIE | SDIO_MASK_DBCKENDIE |
+                SDIO_MASK_DCRCFAILIE | SDIO_MASK_DTIMEOUTIE |
+                SDIO_MASK_TXUNDERRIE;
+
+  /* ST single-block flow: DTEN before the command. */
   SDIO->DCTRL =
       (9 << SDIO_DCTRL_DBLOCKSIZE_Pos) | SDIO_DCTRL_DMAEN | SDIO_DCTRL_DTEN;
 
   if (hal_sdio_send_command(SD_CMD_WRITE_SINGLE_BLOCK, addr, 1)) {
+    SDIO->MASK &= ~(SDIO_MASK_DATAENDIE | SDIO_MASK_DBCKENDIE |
+                    SDIO_MASK_DCRCFAILIE | SDIO_MASK_DTIMEOUTIE |
+                    SDIO_MASK_TXUNDERRIE);
     SDIO->DCTRL = 0;
+    sd_busy = 0;
     hal_dma_stop((const hal_dma_config_t *)&dma2_stream6_cfg);
     return HAL_SDIO_ERROR;
   }
   hal_dma_start((const hal_dma_config_t *)&dma2_stream6_cfg);
-
-  sd_busy = 1;
-  dma_done = 0;
-  sdio_done = 0;
-  sd_last_error = HAL_SDIO_OK;
-
-  /* Enable SDIO interrupts: DATAEND, DBCKEND, and error flags */
-  SDIO->MASK |= SDIO_MASK_DATAENDIE | SDIO_MASK_DBCKENDIE |
-                SDIO_MASK_DCRCFAILIE | SDIO_MASK_DTIMEOUTIE |
-                SDIO_MASK_TXUNDERRIE;
 
   return HAL_SDIO_PENDING;
 }
 
 hal_sdio_error_t hal_sdio_read_blocks_async(uint32_t addr, uint8_t *buf,
                                         uint32_t count) {
+  sd_last_was_write = 0;
   if (sd_busy)
     return HAL_SDIO_BUSY;
 
@@ -644,30 +671,42 @@ hal_sdio_error_t hal_sdio_read_blocks_async(uint32_t addr, uint8_t *buf,
   SDIO->DTIMER = 0xFFFFFFFF;
   SDIO->DLEN = 512 * count;
 
-  if (hal_sdio_send_command(SD_CMD_READ_MULT_BLOCK, addr, 1)) {
-    hal_dma_stop((const hal_dma_config_t *)&dma2_stream3_cfg);
-#ifdef _SDIO_BACKEND_DMA
-//    hal_uart_write_string(HAL_UART_2, "Read Multi CMD18 failed\r\n");
-#endif
-    return HAL_SDIO_ERROR;
-  }
+  /* Arm rendezvous + IRQs BEFORE the trigger (see read_block_async). STBITERRIE
+   * is included so a 4-bit-mode start-bit error is reported instead of stalling
+   * the DPSM in Idle with no DATAEND. */
+  dma_done = 0;
+  sdio_done = 0;
+  is_multi_block = 1;
+  sd_last_error = HAL_SDIO_OK;
+  sd_busy = 1;
+  SDIO->MASK |= SDIO_MASK_DATAENDIE | SDIO_MASK_DBCKENDIE |
+                SDIO_MASK_DCRCFAILIE | SDIO_MASK_DTIMEOUTIE |
+                SDIO_MASK_RXOVERRIE | SDIO_MASK_STBITERRIE;
 
-  /* Enable DPSM AFTER command per spec */
+  /* READ: enable the DPSM (DTEN) and arm DMA BEFORE issuing CMD18, so the DPSM is
+   * parked in Wait_R ready to catch the card's start bit. The card streams the
+   * first block a few SDIO_CK cycles after its CMD18 response; if DTEN is set
+   * AFTER the command (the old order) the DPSM is still in Idle and the start bit
+   * is missed -> CRC fail / lost data / no DATAEND (silent stall until the
+   * wait_sync timeout fires CMD12). RM0368 §21.3 DPSM: receive requires the data
+   * control register written (DTEN=1) so the DPSM is in Wait_R before data
+   * arrives. The single-block read path (read_block_async) already does this;
+   * the multi-block path was the lone exception and raced non-deterministically. */
   SDIO->DCTRL = (9 << SDIO_DCTRL_DBLOCKSIZE_Pos) | SDIO_DCTRL_DTDIR |
                 SDIO_DCTRL_DMAEN | SDIO_DCTRL_DTEN;
 
   hal_dma_start((const hal_dma_config_t *)&dma2_stream3_cfg);
 
-  sd_busy = 1;
-  dma_done = 0;
-  sdio_done = 0;
-  is_multi_block = 1;
-  sd_last_error = HAL_SDIO_OK;
-
-  /* Enable SDIO interrupts: DATAEND, DBCKEND, and error flags */
-  SDIO->MASK |= SDIO_MASK_DATAENDIE | SDIO_MASK_DBCKENDIE |
-                SDIO_MASK_DCRCFAILIE | SDIO_MASK_DTIMEOUTIE |
-                SDIO_MASK_RXOVERRIE;
+  if (hal_sdio_send_command(SD_CMD_READ_MULT_BLOCK, addr, 1)) {
+    SDIO->MASK &= ~(SDIO_MASK_DATAENDIE | SDIO_MASK_DBCKENDIE |
+                    SDIO_MASK_DCRCFAILIE | SDIO_MASK_DTIMEOUTIE |
+                    SDIO_MASK_RXOVERRIE | SDIO_MASK_STBITERRIE);
+    SDIO->DCTRL = 0;
+    sd_busy = 0;
+    is_multi_block = 0;
+    hal_dma_stop((const hal_dma_config_t *)&dma2_stream3_cfg);
+    return HAL_SDIO_ERROR;
+  }
 
   return HAL_SDIO_PENDING;
 }
@@ -676,9 +715,16 @@ hal_sdio_error_t hal_sdio_write_blocks_async(uint32_t addr, const uint8_t *buf,
                                          uint32_t count) {
   if (sd_busy)
     return HAL_SDIO_BUSY;
+  sd_last_was_write = 1;
 
   if (!card_is_sdhc)
     addr *= 512;
+
+  /* Wait for the card to be in TRANSFER state before issuing CMD25. Every other
+   * async entry does this; the multi-block write was the lone exception, so a
+   * CMD25 could collide with a card still PROGRAMMING from a previous write. */
+  if (sdio_wait_card_ready())
+    return HAL_SDIO_TIMEOUT;
 
   SDIO->ICR = 0xFFFFFFFF;
 
@@ -717,22 +763,24 @@ hal_sdio_error_t hal_sdio_write_blocks_async(uint32_t addr, const uint8_t *buf,
     return HAL_SDIO_ERROR;
   }
 
+  /* Arm rendezvous + IRQs BEFORE the data-phase trigger (dma_start / DTEN), so a
+   * fast or preemption-delayed completion IRQ can't be erased (see
+   * read_block_async). CMD25 already succeeded above; the data phase has not
+   * started yet, so this is the correct window. */
+  dma_done = 0;
+  sdio_done = 0;
+  is_multi_block = 1;
+  sd_last_error = HAL_SDIO_OK;
+  sd_busy = 1;
+  SDIO->MASK |= SDIO_MASK_DATAENDIE | SDIO_MASK_DCRCFAILIE |
+                SDIO_MASK_DTIMEOUTIE | SDIO_MASK_TXUNDERRIE;
+
   /* FIX: Start DMA FIRST so it pre-fills the SDIO FIFO */
   hal_dma_start((const hal_dma_config_t *)&dma2_stream6_cfg);
 
   /* FIX: Enable DPSM AFTER DMA is running to avoid TXUNDERRUN */
   SDIO->DCTRL =
       (9 << SDIO_DCTRL_DBLOCKSIZE_Pos) | SDIO_DCTRL_DMAEN | SDIO_DCTRL_DTEN;
-
-  sd_busy = 1;
-  dma_done = 0;
-  sdio_done = 0;
-  is_multi_block = 1;
-  sd_last_error = HAL_SDIO_OK;
-
-  /* Enable SDIO interrupts: DATAEND and error flags */
-  SDIO->MASK |= SDIO_MASK_DATAENDIE | SDIO_MASK_DCRCFAILIE |
-                SDIO_MASK_DTIMEOUTIE | SDIO_MASK_TXUNDERRIE;
 
   return HAL_SDIO_PENDING;
 }
@@ -745,6 +793,8 @@ void SDIO_IRQHandler(void) {
     err = HAL_SDIO_CRC_FAIL;
   else if (sta & SDIO_STA_DTIMEOUT)
     err = HAL_SDIO_TIMEOUT;
+  else if (sta & SDIO_STA_STBITERR)
+    err = HAL_SDIO_ERROR; /* start-bit error: DPSM missed the data start bit */
   else if (sta & SDIO_STA_RXOVERR)
     err = HAL_SDIO_RX_OVERRUN;
   else if (sta & SDIO_STA_TXUNDERR)
@@ -754,8 +804,17 @@ void SDIO_IRQHandler(void) {
   if (err != HAL_SDIO_OK || (sta & SDIO_STA_DATAEND)) {
     SDIO->MASK &=
         ~(SDIO_MASK_DATAENDIE | SDIO_MASK_DBCKENDIE | SDIO_MASK_DCRCFAILIE |
-          SDIO_MASK_DTIMEOUTIE | SDIO_MASK_RXOVERRIE | SDIO_MASK_TXUNDERRIE);
-    SDIO->ICR = 0xFFFFFFFF;
+          SDIO_MASK_DTIMEOUTIE | SDIO_MASK_RXOVERRIE | SDIO_MASK_TXUNDERRIE |
+          SDIO_MASK_STBITERRIE);
+    /* Clear ONLY the data-path flags — NOT the command flags. A single-block
+     * read's data phase can finish (DATAEND) while the synchronous CMD17
+     * send_command() poll, preempted by the RTOS, has not yet observed CMDREND.
+     * A blanket ICR=0xFFFFFFFF here wiped CMDREND out from under that poll → the
+     * poll exhausted its budget and returned a FALSE HAL_SDIO_TIMEOUT (STA read
+     * back as 0x0) → disk_read RES_ERROR → FR_DISK_ERR → the FIL latched the
+     * error and the download stalled. Leaving CMDREND set lets the poll succeed
+     * whenever it resumes; the next command's ICR=0xFFFFFFFF clears it. */
+    SDIO->ICR = SDIO_ICR_DATA_FLAGS;
     SDIO->DCTRL = 0;
     sd_last_error = err;
     sdio_done = 1;
@@ -810,25 +869,69 @@ hal_sdio_error_t hal_sdio_wait_sync(hal_sdio_error_t result) {
     __asm volatile("nop");
   }
 
-  if (hal_timebase_get_millis() - start >= timeout_ms) {
+  /* Decide "did the transfer wedge?" by the COMPLETION FLAG (sd_busy), NOT by
+   * wall-clock elapsed time. The SDIO/DMA completion is IRQ-driven and clears
+   * sd_busy regardless of which task is running; under a preemptive RTOS the
+   * caller (FS task) can be descheduled mid-wait for longer than timeout_ms while
+   * the op completes perfectly in the background. Keying the "timeout" off elapsed
+   * wall-clock then force-aborts a transfer that already SUCCEEDED — returning a
+   * spurious HAL_SDIO_TIMEOUT that truncates uploads / corrupts downloads. This is
+   * exactly why the bug vanished bare-metal / single-task (no preemption -> elapsed
+   * ~= real op time) but struck under the FC's scheduler. The while-loop only
+   * breaks with sd_busy still set (a genuine hang); a normal completion exits with
+   * sd_busy == 0, so `if (sd_busy)` is the correct wedged-transfer discriminator. */
+  if (sd_busy) {
+    /* The transfer wedged (a DMA/SDIO completion IRQ never arrived). Force the
+     * driver back to a clean idle state, otherwise sd_busy stays 1 forever and
+     * EVERY subsequent op returns HAL_SDIO_BUSY — the file silently freezes at
+     * the current offset. Tear down the DPSM, stop any open multi-block stream,
+     * and clear the rendezvous flags so the next request starts fresh. */
+    SDIO->MASK &=
+        ~(SDIO_MASK_DATAENDIE | SDIO_MASK_DBCKENDIE | SDIO_MASK_DCRCFAILIE |
+          SDIO_MASK_DTIMEOUTIE | SDIO_MASK_RXOVERRIE | SDIO_MASK_TXUNDERRIE |
+          SDIO_MASK_STBITERRIE);
+    SDIO->ICR = 0xFFFFFFFF;
+    SDIO->DCTRL = 0;
+    if (is_multi_block)
+      hal_sdio_send_command(SD_CMD_STOP_TRANSMISSION, sd_rca, 1);
+    is_multi_block = 0;
+    dma_done = 0;
+    sdio_done = 0;
+    sd_busy = 0;
+    sd_last_error = HAL_SDIO_TIMEOUT;
     return HAL_SDIO_TIMEOUT;
   }
 
-  if (sd_last_error == HAL_SDIO_OK && is_multi_block) {
-    if (hal_sdio_send_command(SD_CMD_STOP_TRANSMISSION, sd_rca, 1) != HAL_SDIO_OK) {
-      return HAL_SDIO_ERROR;
+  if (sd_last_error == HAL_SDIO_OK) {
+    /* Multi-block transfers need an explicit STOP (CMD12) first. */
+    if (is_multi_block) {
+      if (hal_sdio_send_command(SD_CMD_STOP_TRANSMISSION, sd_rca, 1) != HAL_SDIO_OK) {
+        return HAL_SDIO_ERROR;
+      }
+      is_multi_block = 0;
     }
 
-    uint32_t start = hal_timebase_get_millis();
-    while (sdio_wait_card_ready() != HAL_SDIO_OK) {
-      if ((uint32_t)(hal_timebase_get_millis() - start) >= 500) {
-        return HAL_SDIO_TIMEOUT;
+    /* After a WRITE, wait for the card to leave PROGRAMMING/busy and return to
+     * TRANSFER before the next SDIO op — REQUIRED for single-block writes too, not
+     * just multi-block. A single-block write's DATAEND fires when the block
+     * reaches the card, but the card then holds D0 low while it programs flash;
+     * issuing the next command in that window collides and corrupts the FAT under
+     * sustained writes (e.g. a file upload — low-rate logging to preallocated
+     * files had idle gaps that hid this). Writes only: a read needs no programming
+     * wait, and an extra CMD13 there disrupts the read flow. */
+    if (sd_last_was_write) {
+      uint32_t cr_start = hal_timebase_get_millis();
+      while (sdio_wait_card_ready() != HAL_SDIO_OK) {
+        if ((uint32_t)(hal_timebase_get_millis() - cr_start) >= 500) {
+          return HAL_SDIO_TIMEOUT;
+        }
       }
     }
-
-    is_multi_block = 0;
   }
 
+  /* Always clear: if the transfer errored, the OK-guarded block above was
+   * skipped, so a stuck is_multi_block=1 would poison the next single-block op. */
+  is_multi_block = 0;
   return sd_last_error;
 }
 #endif

--- a/tests/cap/sdio/test_sdio.c
+++ b/tests/cap/sdio/test_sdio.c
@@ -30,6 +30,7 @@
 
 #if NAVHAL_HAS_SDIO
 
+#include "family/sdio_reg.h"
 #include "navhal_port_sdio.h"
 #include "navtest/navtest.h"
 
@@ -73,12 +74,71 @@ void test_hal_sdio_set_callback_smoke(void) {
   hal_sdio_set_callback(NULL); /* re-clear */
   TEST_ASSERT_TRUE(1);
 }
+
+/* --- ISR clear-mask invariant -------------------------------------------- *
+ * Regression guard for an intermittent file-transfer stall: the SDIO data-
+ * completion ISR clears its transfer with SDIO_ICR_DATA_FLAGS and must NEVER
+ * clear the command-path flags (CMDREND in particular) that the synchronous
+ * send_command() poll is waiting on. For a fast single-block read the data
+ * phase can finish — firing the ISR — before a preempted poll has observed
+ * CMDREND; a blanket ICR = 0xFFFFFFFF in the ISR then erases CMDREND, the poll
+ * times out on a command that actually succeeded, and FatFS turns the spurious
+ * HAL_SDIO_TIMEOUT into FR_DISK_ERR and wedges. These are pure constant checks
+ * (no card, no peripheral state), so they hold on any board and in PIL. The
+ * expected sets below are re-derived from the individual bits — independent of
+ * the grouped macros — so a bad edit to either mask is actually caught. */
+#define EXPECT_DATA_CLEAR                                                       \
+  (SDIO_ICR_DCRCFAILC | SDIO_ICR_DTIMEOUTC | SDIO_ICR_TXUNDERRC |              \
+   SDIO_ICR_RXOVERRC | SDIO_ICR_DATAENDC | SDIO_ICR_STBITERRC |               \
+   SDIO_ICR_DBCKENDC)
+#define EXPECT_CMD_CLEAR                                                        \
+  (SDIO_ICR_CCRCFAILC | SDIO_ICR_CTIMEOUTC | SDIO_ICR_CMDRENDC |              \
+   SDIO_ICR_CMDSENTC)
+
+/* THE invariant: the data and command clear families share no bit, so an ISR
+ * writing SDIO_ICR_DATA_FLAGS cannot disturb any command flag. */
+void test_sdio_data_and_command_clear_masks_are_disjoint(void) {
+  TEST_ASSERT_EQUAL_UINT32(
+      0u, (uint32_t)(SDIO_ICR_DATA_FLAGS & SDIO_ICR_CMD_FLAGS));
+}
+
+/* Name the exact flag from the bug. */
+void test_sdio_cmdrend_not_in_data_clear(void) {
+  TEST_ASSERT_EQUAL_UINT32(0u,
+                           (uint32_t)(SDIO_ICR_DATA_FLAGS & SDIO_ICR_CMDRENDC));
+}
+
+/* Cover every data-path flag — a forgotten one leaves the DPSM flagged and
+ * wedges the next transfer instead. */
+void test_sdio_data_clear_covers_all_data_flags(void) {
+  TEST_ASSERT_EQUAL_UINT32((uint32_t)EXPECT_DATA_CLEAR,
+                           (uint32_t)SDIO_ICR_DATA_FLAGS);
+}
+
+/* The command clear is the complete complement, CMDREND included. */
+void test_sdio_command_clear_covers_all_command_flags(void) {
+  TEST_ASSERT_EQUAL_UINT32((uint32_t)EXPECT_CMD_CLEAR,
+                           (uint32_t)SDIO_ICR_CMD_FLAGS);
+}
+
+/* A blanket clear (0xFFFFFFFF) is the regression that caused the stall; an
+ * empty mask would never clear the transfer. Reject both. */
+void test_sdio_data_clear_is_not_a_blanket_clear(void) {
+  TEST_ASSERT_TRUE(SDIO_ICR_DATA_FLAGS != 0xFFFFFFFFu);
+  TEST_ASSERT_TRUE(SDIO_ICR_DATA_FLAGS != 0u);
+}
+
 /* PROGMEM slot for each case name on AVR; no-op elsewhere. */
 NAVTEST_CASE_DECL(test_hal_sdio_init_rejects_null_config);
 NAVTEST_CASE_DECL(test_hal_sdio_read_block_rejects_null_buffer);
 NAVTEST_CASE_DECL(test_hal_sdio_write_block_rejects_null_buffer);
 NAVTEST_CASE_DECL(test_hal_sdio_get_sector_count_returns_value);
 NAVTEST_CASE_DECL(test_hal_sdio_set_callback_smoke);
+NAVTEST_CASE_DECL(test_sdio_data_and_command_clear_masks_are_disjoint);
+NAVTEST_CASE_DECL(test_sdio_cmdrend_not_in_data_clear);
+NAVTEST_CASE_DECL(test_sdio_data_clear_covers_all_data_flags);
+NAVTEST_CASE_DECL(test_sdio_command_clear_covers_all_command_flags);
+NAVTEST_CASE_DECL(test_sdio_data_clear_is_not_a_blanket_clear);
 
 
 static const navtest_case_t sdio_cases[] = {
@@ -87,6 +147,11 @@ static const navtest_case_t sdio_cases[] = {
     NAVTEST_CASE(test_hal_sdio_write_block_rejects_null_buffer),
     NAVTEST_CASE(test_hal_sdio_get_sector_count_returns_value),
     NAVTEST_CASE(test_hal_sdio_set_callback_smoke),
+    NAVTEST_CASE(test_sdio_data_and_command_clear_masks_are_disjoint),
+    NAVTEST_CASE(test_sdio_cmdrend_not_in_data_clear),
+    NAVTEST_CASE(test_sdio_data_clear_covers_all_data_flags),
+    NAVTEST_CASE(test_sdio_command_clear_covers_all_command_flags),
+    NAVTEST_CASE(test_sdio_data_clear_is_not_a_blanket_clear),
 };
 
 const navtest_suite_t test_sdio_suite = {

--- a/tests/cap/sdio/test_sdio.h
+++ b/tests/cap/sdio/test_sdio.h
@@ -41,6 +41,11 @@ void test_hal_sdio_read_block_rejects_null_buffer(void);
 void test_hal_sdio_write_block_rejects_null_buffer(void);
 void test_hal_sdio_get_sector_count_returns_value(void);
 void test_hal_sdio_set_callback_smoke(void);
+void test_sdio_data_and_command_clear_masks_are_disjoint(void);
+void test_sdio_cmdrend_not_in_data_clear(void);
+void test_sdio_data_clear_covers_all_data_flags(void);
+void test_sdio_command_clear_covers_all_command_flags(void);
+void test_sdio_data_clear_is_not_a_blanket_clear(void);
 
 extern const navtest_suite_t test_sdio_suite;
 


### PR DESCRIPTION
## Summary

Fixes an intermittent, RTOS-only SDIO read failure that stalled file transfers,
plus a cluster of related single-block SDIO robustness fixes from the same
debugging pass, and pins the key invariant with tests.

### The headline fix — CMDREND cleared out from under the command poll
The data-completion ISR cleared the whole status register with
`ICR = 0xFFFFFFFF`, which also wiped `CMDREND`. For a fast single-block read the
data phase can finish (firing the ISR) before a **preempted** `send_command()`
poll has observed `CMDREND`; the blanket clear then erased it, the poll ran out
its budget on a command that actually succeeded, and returned a spurious
`HAL_SDIO_TIMEOUT`. FatFS turns that into `FR_DISK_ERR`, latches the file
handle, and the transfer wedges — only under a preemptive scheduler, which is
why bare-metal never reproduced it.

Fix: split the status flags into `SDIO_ICR_DATA_FLAGS` / `SDIO_ICR_CMD_FLAGS`
(`family/sdio_reg.h`) and clear **only the data family** in the ISR.

### Also in this PR (same `sdio.c` pass)
- multi-block read (CMD18): arm `DTEN` + DMA *before* the command so the DPSM is
  parked in `Wait_R` before the card streams data;
- decode + mask `SDIO_STA_STBITERR` on both read paths and in the ISR;
- `wait_sync`: judge a wedged transfer by the completion flag (`sd_busy`), not
  wall-clock elapsed time, so preemption can't false-abort a transfer that
  completed in the background;
- cache the CSD during init (STANDBY window, between CMD3 and CMD7) so
  `hal_sdio_get_sector_count()` works in TRANSFER state where CMD9 is illegal.

### Tests
Adds five cases to the SDIO suite pinning the clear-mask invariant: the data and
command clear families stay **disjoint** (CMDREND never in the data clear), each
is complete, and the data clear is never a blanket `0xFFFFFFFF`. Pure constant
checks — no card needed, run on-target and in PIL.

### Validation
The downstream consumer (a flight-controller file-transfer stack) went from
"everything ≥1 KB corrupts or stalls" to **100% byte-perfect round-trips to
64 KB** with this fix (its own cursor-race fix lives in the consumer). Host
tests + kconfig configure pass via the pre-commit hook; AVR portable samples
12/0 via pre-push.

### Release
Targets `stable` per the patch policy (consumers track `stable`). Bumps
`0.2.4 → 0.2.5` for the semver gate. The unrelated `uart`/`v_fs` submodule
changes are intentionally **not** here — they'll follow as a separate patch once
this lands.
