### PR TITLE
fix(uart,v_fs): TX DMA stream conflict + descriptor slot leak

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 # disagree: bumping one without the other is a release-process bug, not
 # something we want to silently build. This check runs on every configure,
 # including when NavHAL is consumed as a submodule.
-set(NAVHAL_VERSION 0.2.5) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
+set(NAVHAL_VERSION 0.2.6) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/include/navhal.h" _navhal_h)
 string(REGEX MATCH "#define[ \t]+VERSION_MAJOR[ \t]+([0-9]+)" _ "${_navhal_h}")
 set(_navhal_h_major "${CMAKE_MATCH_1}")

--- a/include/navhal.h
+++ b/include/navhal.h
@@ -36,7 +36,7 @@
 /* Release version (SemVer) — the version of this NavHAL distribution. */
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 2
-#define VERSION_PATCH 5
+#define VERSION_PATCH 6
 #define VERSION "0.2.3"
 
 /**

--- a/src/utils/v_fs.c
+++ b/src/utils/v_fs.c
@@ -80,11 +80,12 @@ int v_close(v_fd_t fd) {
   if (fd < 0 || fd >= MAX_OPEN_FILES || !file_in_use[fd])
     return -1;
   FRESULT res = f_close(&open_files[fd]);
-  if (res == FR_OK) {
-    file_in_use[fd] = 0;
-    return 0;
-  }
-  return -(int)res;
+  /* Free the slot UNCONDITIONALLY: f_close invalidates the FIL even on an error
+   * (e.g. a sync write fault), so keeping file_in_use[fd]=1 would leak the slot
+   * permanently and, after MAX_OPEN_FILES such errors, make every subsequent
+   * open fail. Report the error, but never strand the descriptor. */
+  file_in_use[fd] = 0;
+  return (res == FR_OK) ? 0 : -(int)res;
 }
 
 int v_read(v_fd_t fd, void *buf, size_t count) {

--- a/src/vendor/stm32/uart/uart.c
+++ b/src/vendor/stm32/uart/uart.c
@@ -366,9 +366,15 @@ static _uart_dma_params_t _get_uart_dma_params(hal_uart_t uart, int is_tx) {
     p.controller = DMA2;
     p.periph_addr = USART6_BASE + 0x04;
     if (is_tx) {
-      p.stream = 6;
+      /* USART6_TX uses the Stream7/Ch5 alternate mapping, NOT Stream6/Ch5: DMA2
+       * Stream6 is owned by the SDIO write-DMA (vendor/stm32/sdio/sdio.c), so
+       * sharing Stream6 makes the SDIO IRQ steal USART6_TX completions and wedges
+       * telemetry (e.g. dead after the first calibration/log SD write). Stream7 is
+       * conflict-free. Consumers attach their TX-complete callback to
+       * DMA2_Stream7_IRQn (see vayu src/comm/channel.c). */
+      p.stream = 7;
       p.channel = 5;
-      p.irq = DMA2_Stream6_IRQn;
+      p.irq = DMA2_Stream7_IRQn;
     } else {
       p.stream = 1;
       p.channel = 5;


### PR DESCRIPTION
## Summary

Two small, independent fixes that surfaced during the same flight-controller
debugging pass, plus the semver bump. Both are unrelated subsystems, so they're
separate commits.

### `fix(uart)` — USART6 TX DMA collided with SDIO
USART6_TX was mapped to **DMA2 Stream6/Ch5**, but Stream6 is owned by the SDIO
write-DMA. Sharing it let the SDIO completion IRQ steal USART6_TX completions,
wedging telemetry after the first calibration/log SD write. Moved USART6_TX to
the conflict-free **Stream7/Ch5** alternate mapping; consumers attach their
TX-complete callback to `DMA2_Stream7_IRQn`.

### `fix(v_fs)` — descriptor slot leaked on close error
`v_close` only freed `file_in_use[fd]` when `f_close` returned `FR_OK`. But
`f_close` invalidates the FIL even on error (e.g. a sync write fault), so a
failed close left the slot marked in-use forever — after `MAX_OPEN_FILES` such
errors every subsequent `open` failed. Now frees the slot **unconditionally**
and still reports the error code.

### Release
Targets `stable` per the patch policy. Bumps `0.2.5 → 0.2.6` for the semver
gate. Follows #40 (the SDIO fix); these are the remaining changes from that
debugging pass.
