### PR TITLE
chore: reconcile stable (0.2.3) fixes into main

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 # disagree: bumping one without the other is a release-process bug, not
 # something we want to silently build. This check runs on every configure,
 # including when NavHAL is consumed as a submodule.
-set(NAVHAL_VERSION 0.2.1) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
+set(NAVHAL_VERSION 0.2.2) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/include/navhal.h" _navhal_h)
 string(REGEX MATCH "#define[ \t]+VERSION_MAJOR[ \t]+([0-9]+)" _ "${_navhal_h}")
 set(_navhal_h_major "${CMAKE_MATCH_1}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 # disagree: bumping one without the other is a release-process bug, not
 # something we want to silently build. This check runs on every configure,
 # including when NavHAL is consumed as a submodule.
-set(NAVHAL_VERSION 0.2.6) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
+set(NAVHAL_VERSION 0.2.7) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/include/navhal.h" _navhal_h)
 string(REGEX MATCH "#define[ \t]+VERSION_MAJOR[ \t]+([0-9]+)" _ "${_navhal_h}")
 set(_navhal_h_major "${CMAKE_MATCH_1}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 # disagree: bumping one without the other is a release-process bug, not
 # something we want to silently build. This check runs on every configure,
 # including when NavHAL is consumed as a submodule.
-set(NAVHAL_VERSION 0.2.2) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
+set(NAVHAL_VERSION 0.2.3) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/include/navhal.h" _navhal_h)
 string(REGEX MATCH "#define[ \t]+VERSION_MAJOR[ \t]+([0-9]+)" _ "${_navhal_h}")
 set(_navhal_h_major "${CMAKE_MATCH_1}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 # disagree: bumping one without the other is a release-process bug, not
 # something we want to silently build. This check runs on every configure,
 # including when NavHAL is consumed as a submodule.
-set(NAVHAL_VERSION 0.2.4) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
+set(NAVHAL_VERSION 0.2.5) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/include/navhal.h" _navhal_h)
 string(REGEX MATCH "#define[ \t]+VERSION_MAJOR[ \t]+([0-9]+)" _ "${_navhal_h}")
 set(_navhal_h_major "${CMAKE_MATCH_1}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 # disagree: bumping one without the other is a release-process bug, not
 # something we want to silently build. This check runs on every configure,
 # including when NavHAL is consumed as a submodule.
-set(NAVHAL_VERSION 0.2.0) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
+set(NAVHAL_VERSION 0.2.1) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/include/navhal.h" _navhal_h)
 string(REGEX MATCH "#define[ \t]+VERSION_MAJOR[ \t]+([0-9]+)" _ "${_navhal_h}")
 set(_navhal_h_major "${CMAKE_MATCH_1}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 # disagree: bumping one without the other is a release-process bug, not
 # something we want to silently build. This check runs on every configure,
 # including when NavHAL is consumed as a submodule.
-set(NAVHAL_VERSION 0.2.3) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
+set(NAVHAL_VERSION 0.2.4) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/include/navhal.h" _navhal_h)
 string(REGEX MATCH "#define[ \t]+VERSION_MAJOR[ \t]+([0-9]+)" _ "${_navhal_h}")
 set(_navhal_h_major "${CMAKE_MATCH_1}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 # disagree: bumping one without the other is a release-process bug, not
 # something we want to silently build. This check runs on every configure,
 # including when NavHAL is consumed as a submodule.
-set(NAVHAL_VERSION 0.2.5) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
+set(NAVHAL_VERSION 0.2.6) # keep in sync with VERSION_MAJOR/MINOR/PATCH in include/navhal.h
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/include/navhal.h" _navhal_h)
 string(REGEX MATCH "#define[ \t]+VERSION_MAJOR[ \t]+([0-9]+)" _ "${_navhal_h}")
 set(_navhal_h_major "${CMAKE_MATCH_1}")

--- a/include/common/hal_i2c.h
+++ b/include/common/hal_i2c.h
@@ -83,6 +83,20 @@ typedef struct {
 hal_status_t hal_i2c_init(hal_i2c_bus_t bus, const hal_i2c_config_t *config);
 
 /**
+ * @brief De-initialize an I²C bus: software-reset the peripheral and clear its
+ *        init-status bit.
+ *
+ * hal_i2c_init() early-returns ::HAL_ERR_NOT_INITIALIZED on an already-init bus
+ * and so skips its SWRST. Recovery paths (bus stuck BUSY, DMA fail) call this
+ * first to clear the init bit and reset the peripheral, so the following
+ * hal_i2c_init() performs the full reset + reconfigure.
+ *
+ * @param bus I²C bus instance.
+ * @return ::HAL_OK.
+ */
+hal_status_t hal_i2c_deinit(hal_i2c_bus_t bus);
+
+/**
  * @brief Write a byte buffer to an I²C device (blocking).
  * @param bus      I²C bus instance.
  * @param dev_addr 7-bit device address.

--- a/include/navhal.h
+++ b/include/navhal.h
@@ -36,8 +36,8 @@
 /* Release version (SemVer) — the version of this NavHAL distribution. */
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 2
-#define VERSION_PATCH 1
-#define VERSION "0.2.1"
+#define VERSION_PATCH 2
+#define VERSION "0.2.2"
 
 /**
  * @brief NavHAL public-API contract version.

--- a/include/navhal.h
+++ b/include/navhal.h
@@ -36,7 +36,7 @@
 /* Release version (SemVer) — the version of this NavHAL distribution. */
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 2
-#define VERSION_PATCH 6
+#define VERSION_PATCH 7
 #define VERSION "0.2.3"
 
 /**

--- a/include/navhal.h
+++ b/include/navhal.h
@@ -36,8 +36,8 @@
 /* Release version (SemVer) — the version of this NavHAL distribution. */
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 2
-#define VERSION_PATCH 2
-#define VERSION "0.2.2"
+#define VERSION_PATCH 3
+#define VERSION "0.2.3"
 
 /**
  * @brief NavHAL public-API contract version.

--- a/include/navhal.h
+++ b/include/navhal.h
@@ -36,7 +36,7 @@
 /* Release version (SemVer) — the version of this NavHAL distribution. */
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 2
-#define VERSION_PATCH 5
+#define VERSION_PATCH 6
 #define VERSION "0.2.3"
 
 /**

--- a/include/navhal.h
+++ b/include/navhal.h
@@ -36,7 +36,7 @@
 /* Release version (SemVer) — the version of this NavHAL distribution. */
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 2
-#define VERSION_PATCH 4
+#define VERSION_PATCH 5
 #define VERSION "0.2.3"
 
 /**

--- a/include/navhal.h
+++ b/include/navhal.h
@@ -36,8 +36,8 @@
 /* Release version (SemVer) — the version of this NavHAL distribution. */
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 2
-#define VERSION_PATCH 0
-#define VERSION "0.2.0"
+#define VERSION_PATCH 1
+#define VERSION "0.2.1"
 
 /**
  * @brief NavHAL public-API contract version.

--- a/include/navhal.h
+++ b/include/navhal.h
@@ -36,7 +36,7 @@
 /* Release version (SemVer) — the version of this NavHAL distribution. */
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 2
-#define VERSION_PATCH 3
+#define VERSION_PATCH 4
 #define VERSION "0.2.3"
 
 /**

--- a/include/port/cortex-m4/navhal_port_interrupt.h
+++ b/include/port/cortex-m4/navhal_port_interrupt.h
@@ -149,6 +149,18 @@ uint32_t hal_interrupt_disable_global(void);
  */
 void hal_interrupt_clear_all_pending(void);
 
+/**
+ * @brief Put the CPU to sleep until the next interrupt (WFI).
+ *
+ * Executes a Wait-For-Interrupt: the core stops the CPU clock and resumes on
+ * the next wakeup event (any enabled interrupt, including SysTick), cutting
+ * idle power instead of spinning. A wakeup event already pending at entry makes
+ * WFI return immediately, so it never deadlocks. Intended for an RTOS idle
+ * task — call once per idle pass so the core sleeps between interrupts rather
+ * than busy-looping.
+ */
+void hal_cpu_idle(void);
+
 /* Deprecated pre-standardization interrupt names — retained as a backward-compat alias. */
 #include "compat/interrupt_compat.h"
 

--- a/include/port/cortex-m4/navhal_port_uart.h
+++ b/include/port/cortex-m4/navhal_port_uart.h
@@ -42,6 +42,31 @@ extern "C" {
    independently of other DMA users. */
 
 /* -------------------------------------------------------------------------- *
+ * IDLE-line interrupt → callback (DMA-independent).
+ *
+ * Lets a consumer wake on the inter-frame gap of a byte-oriented protocol
+ * (SBUS/iBUS/etc.) instead of polling. Typically paired with circular DMA RX:
+ * arm DMA, then attach an idle callback that signals a task to drain the ring.
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @brief Enable the UART IDLE-line interrupt and route it to @p callback.
+ *
+ * The IDLE flag is cleared inside the driver before @p callback runs. The line
+ * is enabled at a maskable (BASEPRI-managed) NVIC priority, so @p callback may
+ * call an RTOS @c *_from_isr primitive (e.g. give a semaphore).
+ *
+ * @param uart      Target UART.
+ * @param callback  Invoked from ISR context on each detected idle frame-gap.
+ * @return HAL_OK, or HAL_ERR_INVALID_ARG for an unknown UART / NULL callback.
+ */
+hal_status_t hal_uart_attach_idle_callback(hal_uart_t uart,
+                                           void (*callback)(void));
+
+/** @brief Disable the IDLE-line interrupt and clear the registered callback. */
+hal_status_t hal_uart_detach_idle_callback(hal_uart_t uart);
+
+/* -------------------------------------------------------------------------- *
  * DMA-backed UART API — available only when the DMA backend is enabled.
  * -------------------------------------------------------------------------- */
 #if defined(_DMA_ENABLED) && defined(_UART_BACKEND_DMA)
@@ -52,6 +77,18 @@ hal_status_t hal_uart_write_dma(hal_uart_t uart, const uint8_t *data,
 /** @brief Set up a UART for DMA-based circular reception. */
 hal_status_t hal_uart_init_dma_rx(hal_uart_t uart, uint8_t *buffer,
                                   uint16_t length);
+/**
+ * @brief Current circular RX write index for a UART set up via
+ *        ::hal_uart_init_dma_rx (i.e. @c length-NDTR on the correct stream).
+ *
+ * Lets consumers track how far the DMA has filled the ring without touching
+ * DMA registers themselves. Valid range is [0, length).
+ *
+ * @param uart       UART previously initialised for DMA RX.
+ * @param out_index  Receives the next-write index.
+ * @return HAL_OK, or HAL_ERR_INVALID_ARG if RX DMA isn't configured / NULL out.
+ */
+hal_status_t hal_uart_dma_rx_index(hal_uart_t uart, uint16_t *out_index);
 /** @brief Transmit a null-terminated string using DMA. */
 hal_status_t hal_uart_write_string_dma(hal_uart_t uart, const char *s);
 

--- a/include/utils/v_fs.h
+++ b/include/utils/v_fs.h
@@ -51,6 +51,25 @@ extern "C" {
 #define V_SEEK_END 2
 
 typedef int v_fd_t;
+typedef int v_dir_t;
+
+/* FatFS short (8.3) names: 12 chars + NUL (FF_USE_LFN = 0). */
+#define V_NAME_MAX 13
+
+/** @brief One directory entry returned by v_readdir(). */
+typedef struct {
+  char name[V_NAME_MAX]; /**< file/dir name (8.3) */
+  uint32_t size;         /**< file size in bytes (0 for directories) */
+  uint8_t is_dir;        /**< 1 if this entry is a directory */
+} v_dirent_t;
+
+/** @brief File/directory status returned by v_stat(). */
+typedef struct {
+  uint32_t size;  /**< file size in bytes (0 for directories) */
+  uint32_t mtime; /**< FatFS packed modified time: (fdate << 16) | ftime */
+  uint8_t is_dir; /**< 1 if the path is a directory */
+  uint8_t exists; /**< 1 if the path exists (else the rest is unset) */
+} v_stat_t;
 
 /**
  * @brief Initialize the filesystem and mount the default drive.
@@ -130,6 +149,36 @@ int v_sync(v_fd_t fd);
  * @return 0 on success, negative FatFS error code otherwise.
  */
 int v_preallocate(const char *path, uint32_t size);
+
+/**
+ * @brief Get the status of a file or directory.
+ * @param path Path (with drive prefix, e.g. "0:log.dat").
+ * @param st   Filled on return; st->exists distinguishes "absent" from "error".
+ * @return 0 on success (path exists), negative FatFS error code otherwise
+ *         (st->exists set to 0).
+ */
+int v_stat(const char *path, v_stat_t *st);
+
+/**
+ * @brief Open a directory for iteration.
+ * @param path Directory path (e.g. "0:" or "0:logs").
+ * @return A directory handle (>= 0) on success, negative error code otherwise.
+ */
+v_dir_t v_opendir(const char *path);
+
+/**
+ * @brief Read the next entry from an open directory.
+ * @param d   Directory handle from v_opendir().
+ * @param ent Filled with the next entry on return.
+ * @return 1 if an entry was read, 0 at end of directory, negative on error.
+ */
+int v_readdir(v_dir_t d, v_dirent_t *ent);
+
+/**
+ * @brief Close a directory handle.
+ * @return 0 on success, negative error code otherwise.
+ */
+int v_closedir(v_dir_t d);
 
 
 #ifdef __cplusplus

--- a/src/arch/armv7e-m/interrupt/interrupt.c
+++ b/src/arch/armv7e-m/interrupt/interrupt.c
@@ -220,6 +220,14 @@ uint32_t hal_interrupt_disable_global(void) {
   return state;
 }
 
+void hal_cpu_idle(void) {
+  /* DSB before WFI so prior memory writes (e.g. clearing a wake flag) retire
+   * first; WFI sleeps the core until a wakeup event. A pending wakeup event at
+   * entry returns immediately, so this cannot deadlock. */
+  __asm volatile("dsb 0xf" : : : "memory");
+  __asm volatile("wfi" : : : "memory");
+}
+
 void hal_interrupt_clear_all_pending(void) {
   /* STM32F401RE wires IRQs 0..81 (NVIC ICPR words 0..2). Writing past
    * that range is a no-op on real silicon but produces "unhandled

--- a/src/board/nucleo_f401re/linker.ld
+++ b/src/board/nucleo_f401re/linker.ld
@@ -45,7 +45,7 @@ SECTIONS {
     _ebss = .;
     __bss_end__ = .;
     _heap_start = .;
-  } > RAM
+  } > RAM AT > RAM
   _heap_end   = ORIGIN(RAM) + LENGTH(RAM);
   _sidata = LOADADDR(.data);
   _estack = ORIGIN(RAM) + LENGTH(RAM);

--- a/src/utils/v_fs.c
+++ b/src/utils/v_fs.c
@@ -24,10 +24,13 @@
 #include "fatfs/ff.h"
 
 #define MAX_OPEN_FILES 4
+#define MAX_OPEN_DIRS 2
 
 static FATFS fs_obj;
 static FIL open_files[MAX_OPEN_FILES];
 static uint8_t file_in_use[MAX_OPEN_FILES] = {0};
+static DIR dir_objs[MAX_OPEN_DIRS];
+static uint8_t dir_in_use[MAX_OPEN_DIRS] = {0};
 
 int v_fs_init(void) {
   FRESULT res = f_mount(&fs_obj, "0:", 1);
@@ -186,4 +189,67 @@ int v_preallocate(const char *path, uint32_t size) {
   f_sync(&fil);
   f_close(&fil);
   return 0;
+}
+
+int v_stat(const char *path, v_stat_t *st) {
+  if (st == NULL)
+    return -1;
+  FILINFO fno;
+  FRESULT res = f_stat(path, &fno);
+  if (res != FR_OK) {
+    st->exists = 0;
+    return -(int)res;
+  }
+  st->exists = 1;
+  st->size = (uint32_t)fno.fsize;
+  st->is_dir = (fno.fattrib & AM_DIR) ? 1 : 0;
+  st->mtime = ((uint32_t)fno.fdate << 16) | (uint32_t)fno.ftime;
+  return 0;
+}
+
+v_dir_t v_opendir(const char *path) {
+  int d = -1;
+  for (int i = 0; i < MAX_OPEN_DIRS; i++) {
+    if (!dir_in_use[i]) {
+      d = i;
+      break;
+    }
+  }
+  if (d == -1)
+    return -1;
+
+  FRESULT res = f_opendir(&dir_objs[d], path);
+  if (res != FR_OK)
+    return -(int)res;
+
+  dir_in_use[d] = 1;
+  return d;
+}
+
+int v_readdir(v_dir_t d, v_dirent_t *ent) {
+  if (d < 0 || d >= MAX_OPEN_DIRS || !dir_in_use[d] || ent == NULL)
+    return -1;
+
+  FILINFO fno;
+  FRESULT res = f_readdir(&dir_objs[d], &fno);
+  if (res != FR_OK)
+    return -(int)res;
+  if (fno.fname[0] == 0)
+    return 0; /* end of directory */
+
+  int i = 0;
+  for (; i < V_NAME_MAX - 1 && fno.fname[i] != 0; i++)
+    ent->name[i] = (char)fno.fname[i];
+  ent->name[i] = '\0';
+  ent->size = (uint32_t)fno.fsize;
+  ent->is_dir = (fno.fattrib & AM_DIR) ? 1 : 0;
+  return 1;
+}
+
+int v_closedir(v_dir_t d) {
+  if (d < 0 || d >= MAX_OPEN_DIRS || !dir_in_use[d])
+    return -1;
+  FRESULT res = f_closedir(&dir_objs[d]);
+  dir_in_use[d] = 0;
+  return (res == FR_OK) ? 0 : -(int)res;
 }

--- a/src/utils/v_fs.c
+++ b/src/utils/v_fs.c
@@ -80,11 +80,12 @@ int v_close(v_fd_t fd) {
   if (fd < 0 || fd >= MAX_OPEN_FILES || !file_in_use[fd])
     return -1;
   FRESULT res = f_close(&open_files[fd]);
-  if (res == FR_OK) {
-    file_in_use[fd] = 0;
-    return 0;
-  }
-  return -(int)res;
+  /* Free the slot UNCONDITIONALLY: f_close invalidates the FIL even on an error
+   * (e.g. a sync write fault), so keeping file_in_use[fd]=1 would leak the slot
+   * permanently and, after MAX_OPEN_FILES such errors, make every subsequent
+   * open fail. Report the error, but never strand the descriptor. */
+  file_in_use[fd] = 0;
+  return (res == FR_OK) ? 0 : -(int)res;
 }
 
 int v_read(v_fd_t fd, void *buf, size_t count) {

--- a/src/vendor/stm32/clock/clock.c
+++ b/src/vendor/stm32/clock/clock.c
@@ -34,29 +34,50 @@
 #include <stdint.h>
 
 /* Internal clock-source toggle helpers (file-local). */
-static void _toggle_hse_clock(uint8_t state) {
+/* Bound on the spin waiting for an RCC ready / status bit to settle. On real
+ * silicon HSI/HSE/PLL lock and the SYSCLK switch complete in well under a
+ * thousand cycles; the generous cap only stops an unbounded hang when a bit
+ * never sets — e.g. PLL/HSE not modelled under QEMU, or a board with no
+ * external crystal. On timeout the caller backs out and leaves the clock on the
+ * reset HSI rather than spinning forever. */
+#define CLOCK_READY_TIMEOUT 1000000UL
+
+/* Spin until `cond` is false or the timeout elapses; return HAL_ERR_TIMEOUT from
+ * the enclosing function on timeout. Used by helpers that return hal_status_t. */
+#define WAIT_OR_TIMEOUT(cond)                                                  \
+  do {                                                                         \
+    uint32_t _to = CLOCK_READY_TIMEOUT;                                        \
+    while (cond) {                                                             \
+      if (--_to == 0u)                                                         \
+        return HAL_ERR_TIMEOUT;                                                \
+    }                                                                          \
+  } while (0)
+
+/* Internal clock-source toggle helpers (file-local). Return HAL_ERR_TIMEOUT if
+ * the ready bit never reaches `state`. */
+static hal_status_t _toggle_hse_clock(uint8_t state) {
   if (state) {
     RCC->CR |= RCC_CR_HSEON;
   } else
     RCC->CR &= ~RCC_CR_HSEON;
-  while (((RCC->CR & RCC_CR_HSERDY) != 0) != (state))
-    ;
+  WAIT_OR_TIMEOUT(((RCC->CR & RCC_CR_HSERDY) != 0) != (state));
+  return HAL_OK;
 }
-static void _toggle_hsi_clock(uint8_t state) {
+static hal_status_t _toggle_hsi_clock(uint8_t state) {
   if (state)
     RCC->CR |= RCC_CR_HSION;
   else
     RCC->CR &= ~RCC_CR_HSION;
-  while (((RCC->CR & RCC_CR_HSIRDY) != 0) != (state))
-    ;
+  WAIT_OR_TIMEOUT(((RCC->CR & RCC_CR_HSIRDY) != 0) != (state));
+  return HAL_OK;
 }
-static void _toggle_pll_clock(uint8_t state) {
+static hal_status_t _toggle_pll_clock(uint8_t state) {
   if (state)
     RCC->CR |= RCC_CR_PLLON;
   else
     RCC->CR &= ~RCC_CR_PLLON;
-  while (((RCC->CR & RCC_CR_PLLRDY) != 0) != (state))
-    ;
+  WAIT_OR_TIMEOUT(((RCC->CR & RCC_CR_PLLRDY) != 0) != (state));
+  return HAL_OK;
 }
 
 /*
@@ -78,22 +99,31 @@ hal_status_t hal_clock_init(const hal_clock_config_t *cfg,
   if (cfg->source == HAL_CLOCK_SOURCE_PLL && pll_cfg == NULL)
     return HAL_ERR_INVALID_ARG;
 
-  // Enable and wait for selected clock source
+  // Enable and wait for selected clock source. On a ready-bit timeout, bail out
+  // immediately: the system clock is left on the reset HSI rather than being
+  // switched onto a source that never came up (which would be a dead clock).
+  hal_status_t st;
   if (cfg->source == HAL_CLOCK_SOURCE_HSE) {
-    _toggle_hse_clock(RCC_ON);
+    if ((st = _toggle_hse_clock(RCC_ON)) != HAL_OK)
+      return st;
   } else if (cfg->source == HAL_CLOCK_SOURCE_HSI) {
-    _toggle_hsi_clock(RCC_ON);
+    if ((st = _toggle_hsi_clock(RCC_ON)) != HAL_OK)
+      return st;
   }
 
   // PLL configuration and enabling (if PLL is selected)
   else if (cfg->source == HAL_CLOCK_SOURCE_PLL) {
     // Enable PLL input source clock and wait for readiness
-    if (pll_cfg->input_src == HAL_CLOCK_SOURCE_HSE)
-      _toggle_hse_clock(RCC_ON);
-    else if (pll_cfg->input_src == HAL_CLOCK_SOURCE_HSI)
-      _toggle_hsi_clock(RCC_ON);
+    if (pll_cfg->input_src == HAL_CLOCK_SOURCE_HSE) {
+      if ((st = _toggle_hse_clock(RCC_ON)) != HAL_OK)
+        return st;
+    } else if (pll_cfg->input_src == HAL_CLOCK_SOURCE_HSI) {
+      if ((st = _toggle_hsi_clock(RCC_ON)) != HAL_OK)
+        return st;
+    }
 
-    _toggle_pll_clock(RCC_OFF);
+    if ((st = _toggle_pll_clock(RCC_OFF)) != HAL_OK)
+      return st;
     RCC->PLLCFGR = 0;
     // Set PLL source (HSI=0, HSE=1)
     if (pll_cfg->input_src == HAL_CLOCK_SOURCE_HSI) {
@@ -107,7 +137,8 @@ hal_status_t hal_clock_init(const hal_clock_config_t *cfg,
         RCC_PLLCFGR_PLLM(pll_cfg->pll_m) | RCC_PLLCFGR_PLLN(pll_cfg->pll_n) |
         RCC_PLLCFGR_PLLP(pll_cfg->pll_p) | RCC_PLLCFGR_PLLQ(pll_cfg->pll_q);
 
-    _toggle_pll_clock(RCC_ON);
+    if ((st = _toggle_pll_clock(RCC_ON)) != HAL_OK)
+      return st; // PLL never locked — stay on HSI instead of hanging.
   }
 
   // Configure flash latency based on target clock
@@ -130,21 +161,18 @@ hal_status_t hal_clock_init(const hal_clock_config_t *cfg,
   (RCC->CFGR) |=
       (RCC_CFGR_PPRE_DIV2 << RCC_CFGR_PPRE2_BIT); // APB2 prescaler = 2
 
-  // Switch system clock source
+  // Switch system clock source (each switch-status wait is bounded too).
   if (cfg->source == HAL_CLOCK_SOURCE_HSI) {
     (RCC->CFGR) &= ~(0x3 << RCC_CFGR_SW_BIT); // Select HSI
-    while ((((RCC->CFGR) >> RCC_CFGR_SWS_BIT) & 0x3) != 0)
-      ;
+    WAIT_OR_TIMEOUT((((RCC->CFGR) >> RCC_CFGR_SWS_BIT) & 0x3) != 0);
   } else if (cfg->source == HAL_CLOCK_SOURCE_HSE) {
     (RCC->CFGR) &= ~(0x3 << RCC_CFGR_SW_BIT);
     (RCC->CFGR) |= (1 << RCC_CFGR_SW_BIT); // Select HSE
-    while ((((RCC->CFGR) >> RCC_CFGR_SWS_BIT) & 0x3) != 1)
-      ;
+    WAIT_OR_TIMEOUT((((RCC->CFGR) >> RCC_CFGR_SWS_BIT) & 0x3) != 1);
   } else if (cfg->source == HAL_CLOCK_SOURCE_PLL) {
     (RCC->CFGR) &= ~(0x3 << RCC_CFGR_SW_BIT);
     (RCC->CFGR) |= (2 << RCC_CFGR_SW_BIT); // Select PLL
-    while ((((RCC->CFGR) >> RCC_CFGR_SWS_BIT) & 0x3) != 2)
-      ;
+    WAIT_OR_TIMEOUT((((RCC->CFGR) >> RCC_CFGR_SWS_BIT) & 0x3) != 2);
   }
 
   // When decreasing frequency (switching from PLL to HSI/HSE), decrease wait

--- a/src/vendor/stm32/family/stm32f4/include/family/sdio_reg.h
+++ b/src/vendor/stm32/family/stm32f4/include/family/sdio_reg.h
@@ -147,6 +147,28 @@ typedef struct {
 #define SDIO_ICR_DBCKENDC (1 << 10)
 #define SDIO_ICR_SDIOITC (1 << 22)
 
+/* Grouped ICR clear masks.
+ *
+ * The SDIO status flags split into two families: COMMAND-path flags, set around a
+ * CPSM command (CMDREND/CMDSENT/CTIMEOUT/CCRCFAIL), and DATA-path flags, set around
+ * a DPSM transfer (DATAEND/DBCKEND/DCRCFAIL/DTIMEOUT/RXOVERR/TXUNDERR/STBITERR).
+ *
+ * These two families must be cleared INDEPENDENTLY. The data-completion ISR clears
+ * its transfer with SDIO_ICR_DATA_FLAGS and must NEVER touch SDIO_ICR_CMD_FLAGS:
+ * the synchronous send_command() poll spins waiting on CMDREND, and for a fast
+ * single-block read the data phase can finish (firing the ISR) before a preempted
+ * poll has observed CMDREND. A blanket ICR = 0xFFFFFFFF in the ISR clears CMDREND
+ * out from under that poll, which then times out on a command that actually
+ * succeeded — a false HAL_SDIO_TIMEOUT that surfaces as FR_DISK_ERR and stalls the
+ * transfer. Keeping the two masks disjoint is the invariant the SDIO tests pin. */
+#define SDIO_ICR_DATA_FLAGS                                                    \
+  (SDIO_ICR_DCRCFAILC | SDIO_ICR_DTIMEOUTC | SDIO_ICR_TXUNDERRC |             \
+   SDIO_ICR_RXOVERRC | SDIO_ICR_DATAENDC | SDIO_ICR_STBITERRC |              \
+   SDIO_ICR_DBCKENDC)
+#define SDIO_ICR_CMD_FLAGS                                                     \
+  (SDIO_ICR_CCRCFAILC | SDIO_ICR_CTIMEOUTC | SDIO_ICR_CMDRENDC |              \
+   SDIO_ICR_CMDSENTC)
+
 /* MASK Register */
 #define SDIO_MASK_CCRCFAILIE (1 << 0)
 #define SDIO_MASK_DCRCFAILIE (1 << 1)

--- a/src/vendor/stm32/family/stm32f4/include/family/uart_reg.h
+++ b/src/vendor/stm32/family/stm32f4/include/family/uart_reg.h
@@ -81,10 +81,14 @@ typedef struct {
   (1                                                                           \
    << 5) ///< RXNE interrupt enable 0: Interrupt is inhibited 1: An USART
          ///< interrupt is generated whenever RXNE=1 in the USART_SR register
+#define USART_CR1_IDLEIE                                                       \
+  (1 << 4) ///< IDLE line interrupt enable: USART interrupt generated whenever
+           ///< IDLE=1 in the USART_SR register
 
 /* Status register bits */
 #define USART_SR_TXE (1 << 7)  ///< Transmit Data Register Empty
 #define USART_SR_RXNE (1 << 5) ///< Read Data Register Not Empty
+#define USART_SR_IDLE (1 << 4) ///< IDLE line detected (cleared by SR then DR read)
 #define USART_SR_TC (1 << 6)   ///< Transmission Complete
 #define USART_SR_PE (1 << 0)   ///< Parity Error
 #define USART_SR_FE (1 << 1)   ///< Framing Error

--- a/src/vendor/stm32/i2c/i2c.c
+++ b/src/vendor/stm32/i2c/i2c.c
@@ -211,6 +211,20 @@ hal_status_t hal_i2c_init(hal_i2c_bus_t bus, const hal_i2c_config_t *config) {
   }
 }
 
+hal_status_t hal_i2c_deinit(hal_i2c_bus_t bus) {
+  I2C_Reg_Typedef *I2C = I2C_GET_BASE(bus);
+
+  // Disable the peripheral and assert/release the software reset so the next
+  // hal_i2c_init() reconfigures from a clean state.
+  I2C->CR1 &= ~I2C_CR1_PE_MASK;
+  I2C->CR1 |= I2C_CR1_SWRST_MASK;
+  I2C->CR1 &= ~I2C_CR1_SWRST_MASK;
+
+  // Clear this bus's init-status bit (mirrors the per-bus bits set in init).
+  __i2c_init_status &= (uint8_t)~(1u << bus);
+  return HAL_OK;
+}
+
 static int _wait_flag(volatile uint32_t *reg, uint32_t mask) {
   int timeout = TIMEOUT;
   while (((*reg & mask) == 0) && --timeout) {

--- a/src/vendor/stm32/sdio/sdio.c
+++ b/src/vendor/stm32/sdio/sdio.c
@@ -39,7 +39,10 @@ static volatile uint8_t sd_busy = 0;
 static volatile uint8_t dma_done = 0;
 static volatile uint8_t sdio_done = 0;
 static volatile uint8_t is_multi_block = 0;
+static volatile uint8_t sd_last_was_write = 0; /* gate the post-op card-ready wait */
 static hal_sdio_error_t sd_last_error = HAL_SDIO_OK;
+static uint32_t sd_csd[4] = {0}; /* CSD cached during init (STANDBY window) */
+static uint8_t sd_csd_valid = 0;
 
 /* ------------------------------------------------------------- */
 /* INIT */
@@ -258,6 +261,18 @@ hal_sdio_error_t hal_sdio_card_init(void) {
   hal_sdio_send_command(SD_CMD_SEND_REL_ADDR, 0, 1);
   sd_rca = hal_sdio_get_response(1) & 0xFFFF0000;
 
+  /* Read the CSD NOW, while the card is in STANDBY (after CMD3, before the CMD7
+   * select moves it to TRANSFER). CMD9 (SEND_CSD) is only legal in STANDBY; issuing
+   * it after selection returns garbage, which is why hal_sdio_get_sector_count()
+   * reported 0 sectors (and f_mkfs aborted with FR_MKFS_ABORTED). Cache it here. */
+  if (hal_sdio_send_command(9, sd_rca, 3) == HAL_SDIO_OK) {
+    sd_csd[0] = SDIO->RESP1;
+    sd_csd[1] = SDIO->RESP2;
+    sd_csd[2] = SDIO->RESP3;
+    sd_csd[3] = SDIO->RESP4;
+    sd_csd_valid = 1;
+  }
+
   hal_sdio_send_command(SD_CMD_SELECT_DESELECT_CARD, sd_rca, 1);
   if (!card_is_sdhc)
     hal_sdio_send_command(SD_CMD_SET_BLOCKLEN, 512, 1);
@@ -436,20 +451,14 @@ hal_sdio_error_t hal_sdio_write_block(uint32_t addr, const uint8_t *buf) {
 }
 
 uint32_t hal_sdio_get_sector_count(void) {
-  uint32_t csd[4];
-
-  /* Send CMD9 (SEND_CSD) to get card capacity. Long response (R2) */
-  if (hal_sdio_send_command(9, sd_rca, 3) != HAL_SDIO_OK) {
+  /* Use the CSD cached at init (STANDBY window). Re-issuing CMD9 here would fail:
+   * the card is in TRANSFER state now and SEND_CSD is only legal in STANDBY. */
+  if (!sd_csd_valid) {
     return 0;
   }
+  const uint32_t *csd = sd_csd;
 
-  /* RESP1 contains bits [127:96], RESP2 [95:64], RESP3 [63:32], RESP4 [31:0]
-   */
-  csd[0] = SDIO->RESP1;
-  csd[1] = SDIO->RESP2;
-  csd[2] = SDIO->RESP3;
-  csd[3] = SDIO->RESP4;
-
+  /* RESP1 contains bits [127:96], RESP2 [95:64], RESP3 [63:32], RESP4 [31:0] */
   /* CSD Structure depends on CSD_STRUCTURE field [127:126] */
   uint8_t csd_struct = (csd[0] >> 30) & 0x3;
 
@@ -486,6 +495,7 @@ static void _sdio_dma_tx_irq_handler(void);
 hal_sdio_error_t hal_sdio_read_block_async(uint32_t addr, uint8_t *buf) {
   if (sd_busy)
     return HAL_SDIO_BUSY;
+  sd_last_was_write = 0;
 
   if (!card_is_sdhc)
     addr *= 512;
@@ -520,27 +530,34 @@ hal_sdio_error_t hal_sdio_read_block_async(uint32_t addr, uint8_t *buf) {
 
   SDIO->DTIMER = 0xFFFFFFFF;
   SDIO->DLEN = 512;
+
+  /* Arm the completion rendezvous + SDIO IRQs BEFORE the trigger. The DMA
+   * stream IRQ is already enabled, so once hal_dma_start()/the command runs a
+   * completion can fire immediately; if dma_done/sdio_done/sd_busy were set
+   * afterwards, that early IRQ is erased and sd_busy stays 1 forever. */
+  dma_done = 0;
+  sdio_done = 0;
+  is_multi_block = 0;
+  sd_last_error = HAL_SDIO_OK;
+  sd_busy = 1;
+  SDIO->MASK |= SDIO_MASK_DATAENDIE | SDIO_MASK_DBCKENDIE |
+                SDIO_MASK_DCRCFAILIE | SDIO_MASK_DTIMEOUTIE |
+                SDIO_MASK_RXOVERRIE | SDIO_MASK_STBITERRIE;
+
   SDIO->DCTRL = (9 << SDIO_DCTRL_DBLOCKSIZE_Pos) | SDIO_DCTRL_DTDIR |
                 SDIO_DCTRL_DMAEN | SDIO_DCTRL_DTEN;
 
   hal_dma_start((const hal_dma_config_t *)&dma2_stream3_cfg);
 
   if (hal_sdio_send_command(SD_CMD_READ_SINGLE_BLOCK, addr, 1)) {
+    SDIO->MASK &= ~(SDIO_MASK_DATAENDIE | SDIO_MASK_DBCKENDIE |
+                    SDIO_MASK_DCRCFAILIE | SDIO_MASK_DTIMEOUTIE |
+                    SDIO_MASK_RXOVERRIE | SDIO_MASK_STBITERRIE);
     SDIO->DCTRL = 0;
+    sd_busy = 0;
     hal_dma_stop((const hal_dma_config_t *)&dma2_stream3_cfg);
     return HAL_SDIO_ERROR;
   }
-
-  sd_busy = 1;
-  dma_done = 0;
-  sdio_done = 0;
-  is_multi_block = 0;
-  sd_last_error = HAL_SDIO_OK;
-
-  /* Enable SDIO interrupts: DATAEND, DBCKEND, and error flags */
-  SDIO->MASK |= SDIO_MASK_DATAENDIE | SDIO_MASK_DBCKENDIE |
-                SDIO_MASK_DCRCFAILIE | SDIO_MASK_DTIMEOUTIE |
-                SDIO_MASK_RXOVERRIE;
 
   return HAL_SDIO_PENDING;
 }
@@ -548,6 +565,7 @@ hal_sdio_error_t hal_sdio_read_block_async(uint32_t addr, uint8_t *buf) {
 hal_sdio_error_t hal_sdio_write_block_async(uint32_t addr, const uint8_t *buf) {
   if (sd_busy)
     return HAL_SDIO_BUSY;
+  sd_last_was_write = 1;
 
   if (!card_is_sdhc)
     addr *= 512;
@@ -582,31 +600,40 @@ hal_sdio_error_t hal_sdio_write_block_async(uint32_t addr, const uint8_t *buf) {
 
   SDIO->DTIMER = 0xFFFFFFFF;
   SDIO->DLEN = 512;
+
+  /* Arm rendezvous + IRQs BEFORE the trigger (see read_block_async). is_multi_block
+   * MUST be reset here too, else a stale 1 from a prior errored multi-block op makes
+   * wait_sync send a spurious CMD12 STOP after this write and report ERROR. */
+  dma_done = 0;
+  sdio_done = 0;
+  is_multi_block = 0;
+  sd_last_error = HAL_SDIO_OK;
+  sd_busy = 1;
+  SDIO->MASK |= SDIO_MASK_DATAENDIE | SDIO_MASK_DBCKENDIE |
+                SDIO_MASK_DCRCFAILIE | SDIO_MASK_DTIMEOUTIE |
+                SDIO_MASK_TXUNDERRIE;
+
+  /* ST single-block flow: DTEN before the command. */
   SDIO->DCTRL =
       (9 << SDIO_DCTRL_DBLOCKSIZE_Pos) | SDIO_DCTRL_DMAEN | SDIO_DCTRL_DTEN;
 
   if (hal_sdio_send_command(SD_CMD_WRITE_SINGLE_BLOCK, addr, 1)) {
+    SDIO->MASK &= ~(SDIO_MASK_DATAENDIE | SDIO_MASK_DBCKENDIE |
+                    SDIO_MASK_DCRCFAILIE | SDIO_MASK_DTIMEOUTIE |
+                    SDIO_MASK_TXUNDERRIE);
     SDIO->DCTRL = 0;
+    sd_busy = 0;
     hal_dma_stop((const hal_dma_config_t *)&dma2_stream6_cfg);
     return HAL_SDIO_ERROR;
   }
   hal_dma_start((const hal_dma_config_t *)&dma2_stream6_cfg);
-
-  sd_busy = 1;
-  dma_done = 0;
-  sdio_done = 0;
-  sd_last_error = HAL_SDIO_OK;
-
-  /* Enable SDIO interrupts: DATAEND, DBCKEND, and error flags */
-  SDIO->MASK |= SDIO_MASK_DATAENDIE | SDIO_MASK_DBCKENDIE |
-                SDIO_MASK_DCRCFAILIE | SDIO_MASK_DTIMEOUTIE |
-                SDIO_MASK_TXUNDERRIE;
 
   return HAL_SDIO_PENDING;
 }
 
 hal_sdio_error_t hal_sdio_read_blocks_async(uint32_t addr, uint8_t *buf,
                                         uint32_t count) {
+  sd_last_was_write = 0;
   if (sd_busy)
     return HAL_SDIO_BUSY;
 
@@ -644,30 +671,42 @@ hal_sdio_error_t hal_sdio_read_blocks_async(uint32_t addr, uint8_t *buf,
   SDIO->DTIMER = 0xFFFFFFFF;
   SDIO->DLEN = 512 * count;
 
-  if (hal_sdio_send_command(SD_CMD_READ_MULT_BLOCK, addr, 1)) {
-    hal_dma_stop((const hal_dma_config_t *)&dma2_stream3_cfg);
-#ifdef _SDIO_BACKEND_DMA
-//    hal_uart_write_string(HAL_UART_2, "Read Multi CMD18 failed\r\n");
-#endif
-    return HAL_SDIO_ERROR;
-  }
+  /* Arm rendezvous + IRQs BEFORE the trigger (see read_block_async). STBITERRIE
+   * is included so a 4-bit-mode start-bit error is reported instead of stalling
+   * the DPSM in Idle with no DATAEND. */
+  dma_done = 0;
+  sdio_done = 0;
+  is_multi_block = 1;
+  sd_last_error = HAL_SDIO_OK;
+  sd_busy = 1;
+  SDIO->MASK |= SDIO_MASK_DATAENDIE | SDIO_MASK_DBCKENDIE |
+                SDIO_MASK_DCRCFAILIE | SDIO_MASK_DTIMEOUTIE |
+                SDIO_MASK_RXOVERRIE | SDIO_MASK_STBITERRIE;
 
-  /* Enable DPSM AFTER command per spec */
+  /* READ: enable the DPSM (DTEN) and arm DMA BEFORE issuing CMD18, so the DPSM is
+   * parked in Wait_R ready to catch the card's start bit. The card streams the
+   * first block a few SDIO_CK cycles after its CMD18 response; if DTEN is set
+   * AFTER the command (the old order) the DPSM is still in Idle and the start bit
+   * is missed -> CRC fail / lost data / no DATAEND (silent stall until the
+   * wait_sync timeout fires CMD12). RM0368 §21.3 DPSM: receive requires the data
+   * control register written (DTEN=1) so the DPSM is in Wait_R before data
+   * arrives. The single-block read path (read_block_async) already does this;
+   * the multi-block path was the lone exception and raced non-deterministically. */
   SDIO->DCTRL = (9 << SDIO_DCTRL_DBLOCKSIZE_Pos) | SDIO_DCTRL_DTDIR |
                 SDIO_DCTRL_DMAEN | SDIO_DCTRL_DTEN;
 
   hal_dma_start((const hal_dma_config_t *)&dma2_stream3_cfg);
 
-  sd_busy = 1;
-  dma_done = 0;
-  sdio_done = 0;
-  is_multi_block = 1;
-  sd_last_error = HAL_SDIO_OK;
-
-  /* Enable SDIO interrupts: DATAEND, DBCKEND, and error flags */
-  SDIO->MASK |= SDIO_MASK_DATAENDIE | SDIO_MASK_DBCKENDIE |
-                SDIO_MASK_DCRCFAILIE | SDIO_MASK_DTIMEOUTIE |
-                SDIO_MASK_RXOVERRIE;
+  if (hal_sdio_send_command(SD_CMD_READ_MULT_BLOCK, addr, 1)) {
+    SDIO->MASK &= ~(SDIO_MASK_DATAENDIE | SDIO_MASK_DBCKENDIE |
+                    SDIO_MASK_DCRCFAILIE | SDIO_MASK_DTIMEOUTIE |
+                    SDIO_MASK_RXOVERRIE | SDIO_MASK_STBITERRIE);
+    SDIO->DCTRL = 0;
+    sd_busy = 0;
+    is_multi_block = 0;
+    hal_dma_stop((const hal_dma_config_t *)&dma2_stream3_cfg);
+    return HAL_SDIO_ERROR;
+  }
 
   return HAL_SDIO_PENDING;
 }
@@ -676,9 +715,16 @@ hal_sdio_error_t hal_sdio_write_blocks_async(uint32_t addr, const uint8_t *buf,
                                          uint32_t count) {
   if (sd_busy)
     return HAL_SDIO_BUSY;
+  sd_last_was_write = 1;
 
   if (!card_is_sdhc)
     addr *= 512;
+
+  /* Wait for the card to be in TRANSFER state before issuing CMD25. Every other
+   * async entry does this; the multi-block write was the lone exception, so a
+   * CMD25 could collide with a card still PROGRAMMING from a previous write. */
+  if (sdio_wait_card_ready())
+    return HAL_SDIO_TIMEOUT;
 
   SDIO->ICR = 0xFFFFFFFF;
 
@@ -717,22 +763,24 @@ hal_sdio_error_t hal_sdio_write_blocks_async(uint32_t addr, const uint8_t *buf,
     return HAL_SDIO_ERROR;
   }
 
+  /* Arm rendezvous + IRQs BEFORE the data-phase trigger (dma_start / DTEN), so a
+   * fast or preemption-delayed completion IRQ can't be erased (see
+   * read_block_async). CMD25 already succeeded above; the data phase has not
+   * started yet, so this is the correct window. */
+  dma_done = 0;
+  sdio_done = 0;
+  is_multi_block = 1;
+  sd_last_error = HAL_SDIO_OK;
+  sd_busy = 1;
+  SDIO->MASK |= SDIO_MASK_DATAENDIE | SDIO_MASK_DCRCFAILIE |
+                SDIO_MASK_DTIMEOUTIE | SDIO_MASK_TXUNDERRIE;
+
   /* FIX: Start DMA FIRST so it pre-fills the SDIO FIFO */
   hal_dma_start((const hal_dma_config_t *)&dma2_stream6_cfg);
 
   /* FIX: Enable DPSM AFTER DMA is running to avoid TXUNDERRUN */
   SDIO->DCTRL =
       (9 << SDIO_DCTRL_DBLOCKSIZE_Pos) | SDIO_DCTRL_DMAEN | SDIO_DCTRL_DTEN;
-
-  sd_busy = 1;
-  dma_done = 0;
-  sdio_done = 0;
-  is_multi_block = 1;
-  sd_last_error = HAL_SDIO_OK;
-
-  /* Enable SDIO interrupts: DATAEND and error flags */
-  SDIO->MASK |= SDIO_MASK_DATAENDIE | SDIO_MASK_DCRCFAILIE |
-                SDIO_MASK_DTIMEOUTIE | SDIO_MASK_TXUNDERRIE;
 
   return HAL_SDIO_PENDING;
 }
@@ -745,6 +793,8 @@ void SDIO_IRQHandler(void) {
     err = HAL_SDIO_CRC_FAIL;
   else if (sta & SDIO_STA_DTIMEOUT)
     err = HAL_SDIO_TIMEOUT;
+  else if (sta & SDIO_STA_STBITERR)
+    err = HAL_SDIO_ERROR; /* start-bit error: DPSM missed the data start bit */
   else if (sta & SDIO_STA_RXOVERR)
     err = HAL_SDIO_RX_OVERRUN;
   else if (sta & SDIO_STA_TXUNDERR)
@@ -754,8 +804,17 @@ void SDIO_IRQHandler(void) {
   if (err != HAL_SDIO_OK || (sta & SDIO_STA_DATAEND)) {
     SDIO->MASK &=
         ~(SDIO_MASK_DATAENDIE | SDIO_MASK_DBCKENDIE | SDIO_MASK_DCRCFAILIE |
-          SDIO_MASK_DTIMEOUTIE | SDIO_MASK_RXOVERRIE | SDIO_MASK_TXUNDERRIE);
-    SDIO->ICR = 0xFFFFFFFF;
+          SDIO_MASK_DTIMEOUTIE | SDIO_MASK_RXOVERRIE | SDIO_MASK_TXUNDERRIE |
+          SDIO_MASK_STBITERRIE);
+    /* Clear ONLY the data-path flags — NOT the command flags. A single-block
+     * read's data phase can finish (DATAEND) while the synchronous CMD17
+     * send_command() poll, preempted by the RTOS, has not yet observed CMDREND.
+     * A blanket ICR=0xFFFFFFFF here wiped CMDREND out from under that poll → the
+     * poll exhausted its budget and returned a FALSE HAL_SDIO_TIMEOUT (STA read
+     * back as 0x0) → disk_read RES_ERROR → FR_DISK_ERR → the FIL latched the
+     * error and the download stalled. Leaving CMDREND set lets the poll succeed
+     * whenever it resumes; the next command's ICR=0xFFFFFFFF clears it. */
+    SDIO->ICR = SDIO_ICR_DATA_FLAGS;
     SDIO->DCTRL = 0;
     sd_last_error = err;
     sdio_done = 1;
@@ -810,25 +869,69 @@ hal_sdio_error_t hal_sdio_wait_sync(hal_sdio_error_t result) {
     __asm volatile("nop");
   }
 
-  if (hal_timebase_get_millis() - start >= timeout_ms) {
+  /* Decide "did the transfer wedge?" by the COMPLETION FLAG (sd_busy), NOT by
+   * wall-clock elapsed time. The SDIO/DMA completion is IRQ-driven and clears
+   * sd_busy regardless of which task is running; under a preemptive RTOS the
+   * caller (FS task) can be descheduled mid-wait for longer than timeout_ms while
+   * the op completes perfectly in the background. Keying the "timeout" off elapsed
+   * wall-clock then force-aborts a transfer that already SUCCEEDED — returning a
+   * spurious HAL_SDIO_TIMEOUT that truncates uploads / corrupts downloads. This is
+   * exactly why the bug vanished bare-metal / single-task (no preemption -> elapsed
+   * ~= real op time) but struck under the FC's scheduler. The while-loop only
+   * breaks with sd_busy still set (a genuine hang); a normal completion exits with
+   * sd_busy == 0, so `if (sd_busy)` is the correct wedged-transfer discriminator. */
+  if (sd_busy) {
+    /* The transfer wedged (a DMA/SDIO completion IRQ never arrived). Force the
+     * driver back to a clean idle state, otherwise sd_busy stays 1 forever and
+     * EVERY subsequent op returns HAL_SDIO_BUSY — the file silently freezes at
+     * the current offset. Tear down the DPSM, stop any open multi-block stream,
+     * and clear the rendezvous flags so the next request starts fresh. */
+    SDIO->MASK &=
+        ~(SDIO_MASK_DATAENDIE | SDIO_MASK_DBCKENDIE | SDIO_MASK_DCRCFAILIE |
+          SDIO_MASK_DTIMEOUTIE | SDIO_MASK_RXOVERRIE | SDIO_MASK_TXUNDERRIE |
+          SDIO_MASK_STBITERRIE);
+    SDIO->ICR = 0xFFFFFFFF;
+    SDIO->DCTRL = 0;
+    if (is_multi_block)
+      hal_sdio_send_command(SD_CMD_STOP_TRANSMISSION, sd_rca, 1);
+    is_multi_block = 0;
+    dma_done = 0;
+    sdio_done = 0;
+    sd_busy = 0;
+    sd_last_error = HAL_SDIO_TIMEOUT;
     return HAL_SDIO_TIMEOUT;
   }
 
-  if (sd_last_error == HAL_SDIO_OK && is_multi_block) {
-    if (hal_sdio_send_command(SD_CMD_STOP_TRANSMISSION, sd_rca, 1) != HAL_SDIO_OK) {
-      return HAL_SDIO_ERROR;
+  if (sd_last_error == HAL_SDIO_OK) {
+    /* Multi-block transfers need an explicit STOP (CMD12) first. */
+    if (is_multi_block) {
+      if (hal_sdio_send_command(SD_CMD_STOP_TRANSMISSION, sd_rca, 1) != HAL_SDIO_OK) {
+        return HAL_SDIO_ERROR;
+      }
+      is_multi_block = 0;
     }
 
-    uint32_t start = hal_timebase_get_millis();
-    while (sdio_wait_card_ready() != HAL_SDIO_OK) {
-      if ((uint32_t)(hal_timebase_get_millis() - start) >= 500) {
-        return HAL_SDIO_TIMEOUT;
+    /* After a WRITE, wait for the card to leave PROGRAMMING/busy and return to
+     * TRANSFER before the next SDIO op — REQUIRED for single-block writes too, not
+     * just multi-block. A single-block write's DATAEND fires when the block
+     * reaches the card, but the card then holds D0 low while it programs flash;
+     * issuing the next command in that window collides and corrupts the FAT under
+     * sustained writes (e.g. a file upload — low-rate logging to preallocated
+     * files had idle gaps that hid this). Writes only: a read needs no programming
+     * wait, and an extra CMD13 there disrupts the read flow. */
+    if (sd_last_was_write) {
+      uint32_t cr_start = hal_timebase_get_millis();
+      while (sdio_wait_card_ready() != HAL_SDIO_OK) {
+        if ((uint32_t)(hal_timebase_get_millis() - cr_start) >= 500) {
+          return HAL_SDIO_TIMEOUT;
+        }
       }
     }
-
-    is_multi_block = 0;
   }
 
+  /* Always clear: if the transfer errored, the OK-guarded block above was
+   * skipped, so a stuck is_multi_block=1 would poison the next single-block op. */
+  is_multi_block = 0;
   return sd_last_error;
 }
 #endif

--- a/src/vendor/stm32/uart/uart.c
+++ b/src/vendor/stm32/uart/uart.c
@@ -120,6 +120,85 @@ hal_status_t hal_uart_enable_interrupt(hal_uart_t uart, uint8_t rx_en,
   return HAL_OK;
 }
 
+/* -------------------------------------------------------------------------- *
+ * IDLE-line interrupt → user callback.
+ *
+ * The IDLE line fires at the inter-frame gap of a byte-oriented protocol
+ * (e.g. SBUS/iBUS), letting a consumer block until a whole frame has arrived
+ * instead of polling. Pairs naturally with circular DMA RX: the DMA fills the
+ * ring, and IDLE signals "a burst just ended — go drain it".
+ * -------------------------------------------------------------------------- */
+
+/** UART -> index into the per-UART tables (UART1=0, UART2=1, UART6=2). */
+static inline int _uart_idx(hal_uart_t uart) {
+  return (uart == HAL_UART_1) ? 0 : (uart == HAL_UART_6) ? 2 : 1;
+}
+
+static void (*_uart_idle_cb[3])(void) = {0};
+
+/* Demux + clear: on the shared USART IRQ, run only if the IDLE flag is set.
+ * F4 has no IDLE-clear bit — the flag is cleared by a read of SR followed by a
+ * read of DR. At IDLE time the line is quiet and DMA has already drained DR, so
+ * the dummy DR read steals no in-flight byte. */
+static void _uart_idle_handle(hal_uart_t uart) {
+  volatile UARTx_Reg_Typedef *usart = _get_usart(uart);
+  if (!usart)
+    return;
+  if (usart->SR & USART_SR_IDLE) {
+    (void)usart->DR; /* SR was just read above; DR read clears IDLE */
+    void (*cb)(void) = _uart_idle_cb[_uart_idx(uart)];
+    if (cb)
+      cb();
+  }
+}
+
+/* The interrupt registry takes a void(void) callback, so one thin trampoline
+ * per USART line carries the UART identity. */
+static void _uart_idle_irq_usart1(void) { _uart_idle_handle(HAL_UART_1); }
+static void _uart_idle_irq_usart2(void) { _uart_idle_handle(HAL_UART_2); }
+static void _uart_idle_irq_usart6(void) { _uart_idle_handle(HAL_UART_6); }
+
+hal_status_t hal_uart_attach_idle_callback(hal_uart_t uart,
+                                           void (*callback)(void)) {
+  volatile UARTx_Reg_Typedef *usart = _get_usart(uart);
+  if (!usart || !callback)
+    return HAL_ERR_INVALID_ARG;
+
+  hal_irq_t irq;
+  void (*trampoline)(void);
+  if (uart == HAL_UART_1) {
+    irq = USART1_IRQn;
+    trampoline = _uart_idle_irq_usart1;
+  } else if (uart == HAL_UART_6) {
+    irq = USART6_IRQn;
+    trampoline = _uart_idle_irq_usart6;
+  } else {
+    irq = USART2_IRQn;
+    trampoline = _uart_idle_irq_usart2;
+  }
+
+  _uart_idle_cb[_uart_idx(uart)] = callback;
+  hal_interrupt_attach_callback(irq, trampoline);
+
+  (void)usart->SR; /* clear any stale IDLE (SR then DR) before arming */
+  (void)usart->DR;
+  usart->CR1 |= USART_CR1_IDLEIE;
+
+  /* Maskable (BASEPRI-managed) priority so the callback may call an RTOS
+   * *_from_isr primitive — same contract as the DMA-completion ISRs. */
+  hal_interrupt_enable_with_priority(irq, HAL_IRQ_PRIORITY_DEFAULT);
+  return HAL_OK;
+}
+
+hal_status_t hal_uart_detach_idle_callback(hal_uart_t uart) {
+  volatile UARTx_Reg_Typedef *usart = _get_usart(uart);
+  if (!usart)
+    return HAL_ERR_INVALID_ARG;
+  usart->CR1 &= ~USART_CR1_IDLEIE;
+  _uart_idle_cb[_uart_idx(uart)] = NULL;
+  return HAL_OK;
+}
+
 hal_status_t hal_uart_write_char(hal_uart_t uart, char c) {
   volatile UARTx_Reg_Typedef *usart = _get_usart(uart);
   if (!usart)
@@ -307,6 +386,10 @@ static _uart_dma_params_t _get_uart_dma_params(hal_uart_t uart, int is_tx) {
  */
 static uint8_t _uart_dma_initialized[6] = {0};
 
+/** Configured circular RX-buffer length per UART (UART1=0, UART2=1, UART6=2);
+ *  0 until hal_uart_init_dma_rx() runs. Used to turn NDTR into a write index. */
+static uint16_t _uart_rx_dma_len[3] = {0};
+
 hal_status_t hal_uart_write_dma(hal_uart_t uart, const uint8_t *data,
                                 uint16_t length) {
   if (!data || length == 0)
@@ -386,6 +469,23 @@ hal_status_t hal_uart_init_dma_rx(hal_uart_t uart, uint8_t *buffer,
 
   int idx = (uart == HAL_UART_1) ? 1 : (uart == HAL_UART_2) ? 3 : 5;
   _uart_dma_initialized[idx] = 1;
+  _uart_rx_dma_len[_uart_idx(uart)] = length;
+  return HAL_OK;
+}
+
+hal_status_t hal_uart_dma_rx_index(hal_uart_t uart, uint16_t *out_index) {
+  if (!out_index)
+    return HAL_ERR_INVALID_ARG;
+  _uart_dma_params_t p = _get_uart_dma_params(uart, 0);
+  uint16_t len = _uart_rx_dma_len[_uart_idx(uart)];
+  if (!p.controller || len == 0)
+    return HAL_ERR_INVALID_ARG; /* RX DMA not configured for this UART */
+
+  /* NDTR counts down from `len` to 0 as the DMA fills the circular buffer, so
+   * the next-write index is len - NDTR. Reading the correct stream's NDTR is
+   * the whole point — callers must not guess the stream themselves. */
+  uint16_t ndtr = (uint16_t)(p.controller->STREAM[p.stream].NDTR & 0xFFFFu);
+  *out_index = (uint16_t)(len - ndtr);
   return HAL_OK;
 }
 

--- a/src/vendor/stm32/uart/uart.c
+++ b/src/vendor/stm32/uart/uart.c
@@ -366,9 +366,15 @@ static _uart_dma_params_t _get_uart_dma_params(hal_uart_t uart, int is_tx) {
     p.controller = DMA2;
     p.periph_addr = USART6_BASE + 0x04;
     if (is_tx) {
-      p.stream = 6;
+      /* USART6_TX uses the Stream7/Ch5 alternate mapping, NOT Stream6/Ch5: DMA2
+       * Stream6 is owned by the SDIO write-DMA (vendor/stm32/sdio/sdio.c), so
+       * sharing Stream6 makes the SDIO IRQ steal USART6_TX completions and wedges
+       * telemetry (e.g. dead after the first calibration/log SD write). Stream7 is
+       * conflict-free. Consumers attach their TX-complete callback to
+       * DMA2_Stream7_IRQn (see vayu src/comm/channel.c). */
+      p.stream = 7;
       p.channel = 5;
-      p.irq = DMA2_Stream6_IRQn;
+      p.irq = DMA2_Stream7_IRQn;
     } else {
       p.stream = 1;
       p.channel = 5;

--- a/tests/arch/cortex-m4/linker.ld
+++ b/tests/arch/cortex-m4/linker.ld
@@ -35,7 +35,7 @@ SECTIONS {
     *(.bss*)
     *(COMMON)
     _ebss = .;
-  } > RAM
+  } > RAM AT > RAM
 
   _sidata = LOADADDR(.data);
   _estack = ORIGIN(RAM) + LENGTH(RAM);

--- a/tests/arch/cortex-m4/test_interrupt.c
+++ b/tests/arch/cortex-m4/test_interrupt.c
@@ -24,6 +24,7 @@
 #include "navhal_port_interrupt.h"
 #include "family/interrupt_reg.h"
 #include "navtest/navtest.h"
+#include "navtest/navtest_pil.h"
 #include "test_interrupt.h"
 
 #include <stdbool.h>
@@ -125,6 +126,29 @@ void test_hal_interrupt_clear_all_pending_zeros_icpr(void) {
   TEST_ASSERT_EQUAL_UINT32(0u, NVIC->ISPR[1]);
 }
 
+void test_hal_cpu_idle_returns_on_pending_irq(void) {
+  /* A wakeup event already pending at WFI entry must make hal_cpu_idle()
+   * return immediately rather than halt — so this exercises the no-deadlock
+   * guarantee. Pend an *enabled* IRQ (a valid wake source) while PRIMASK masks
+   * it (so the handler doesn't actually run), call hal_cpu_idle(), and clear it
+   * before unmasking. Reaching the assert proves WFI returned.
+   *
+   * WFI modelling under Renode can stall the run, so validate on HIL only. */
+  NAVTEST_SKIP_ON_PIL();
+
+  hal_interrupt_clear_pending(TEST_IRQ);
+  hal_interrupt_enable(TEST_IRQ);
+  uint32_t pm = hal_interrupt_disable_global();
+  NVIC->ISPR[iser_word(TEST_IRQ)] = iser_bit(TEST_IRQ); /* pend a wake event */
+
+  hal_cpu_idle(); /* must return (pending event => no halt) */
+
+  hal_interrupt_clear_pending(TEST_IRQ); /* clear before unmasking */
+  hal_interrupt_disable(TEST_IRQ);
+  hal_interrupt_enable_global(pm);
+  TEST_ASSERT_TRUE(1);
+}
+
 /* -------------------- Error-path tests -------------------- */
 
 void test_hal_interrupt_enable_rejects_negative_irq(void) {
@@ -219,6 +243,7 @@ NAVTEST_CASE_DECL(test_hal_interrupt_attach_then_dispatch_runs_callback);
 NAVTEST_CASE_DECL(test_hal_interrupt_detach_clears_callback);
 NAVTEST_CASE_DECL(test_hal_interrupt_disable_then_restore_global);
 NAVTEST_CASE_DECL(test_hal_interrupt_clear_all_pending_zeros_icpr);
+NAVTEST_CASE_DECL(test_hal_cpu_idle_returns_on_pending_irq);
 NAVTEST_CASE_DECL(test_hal_interrupt_enable_rejects_negative_irq);
 NAVTEST_CASE_DECL(test_hal_interrupt_disable_rejects_negative_irq);
 NAVTEST_CASE_DECL(test_hal_interrupt_clear_pending_rejects_negative_irq);
@@ -237,6 +262,7 @@ static const navtest_case_t interrupt_cases[] = {
     NAVTEST_CASE(test_hal_interrupt_detach_clears_callback),
     NAVTEST_CASE(test_hal_interrupt_disable_then_restore_global),
     NAVTEST_CASE(test_hal_interrupt_clear_all_pending_zeros_icpr),
+    NAVTEST_CASE(test_hal_cpu_idle_returns_on_pending_irq),
     /* error paths */
     NAVTEST_CASE(test_hal_interrupt_enable_rejects_negative_irq),
     NAVTEST_CASE(test_hal_interrupt_disable_rejects_negative_irq),

--- a/tests/arch/cortex-m4/test_interrupt.h
+++ b/tests/arch/cortex-m4/test_interrupt.h
@@ -37,6 +37,7 @@ void test_hal_interrupt_is_pending_after_set(void);
 void test_hal_interrupt_attach_then_dispatch_runs_callback(void);
 void test_hal_interrupt_detach_clears_callback(void);
 void test_hal_interrupt_disable_then_restore_global(void);
+void test_hal_cpu_idle_returns_on_pending_irq(void);
 void test_hal_interrupt_clear_all_pending_zeros_icpr(void);
 
 /* error paths */

--- a/tests/arch/cortex-m4/test_uart_protocol.c
+++ b/tests/arch/cortex-m4/test_uart_protocol.c
@@ -140,6 +140,29 @@ void test_hal_uart_available_after_init_is_false(void) {
   init_test_uart(115200);
   TEST_ASSERT_FALSE(hal_uart_available(TEST_UART));
 }
+
+/* -------------------- idle-line callback surface -------------------- */
+
+static void _idle_noop_cb(void) {}
+
+void test_hal_uart_attach_idle_rejects_null_cb(void) {
+  TEST_ASSERT_EQUAL_UINT32(
+      (uint32_t)HAL_ERR_INVALID_ARG,
+      (uint32_t)hal_uart_attach_idle_callback(TEST_UART, NULL));
+}
+
+void test_hal_uart_attach_idle_sets_and_clears_idleie(void) {
+  init_test_uart(115200);
+  volatile UARTx_Reg_Typedef *u = GET_USARTx_BASE(1);
+  TEST_ASSERT_EQUAL_UINT32(
+      (uint32_t)HAL_OK,
+      (uint32_t)hal_uart_attach_idle_callback(TEST_UART, _idle_noop_cb));
+  TEST_ASSERT_TRUE((u->CR1 & USART_CR1_IDLEIE) != 0u);
+  TEST_ASSERT_EQUAL_UINT32(
+      (uint32_t)HAL_OK, (uint32_t)hal_uart_detach_idle_callback(TEST_UART));
+  TEST_ASSERT_TRUE((u->CR1 & USART_CR1_IDLEIE) == 0u);
+}
+
 /* PROGMEM slot for each case name on AVR; no-op elsewhere. */
 NAVTEST_CASE_DECL(test_uart_baudrate_9600);
 NAVTEST_CASE_DECL(test_uart_baudrate_115200);
@@ -153,6 +176,8 @@ NAVTEST_CASE_DECL(test_hal_uart_write_float_returns_ok);
 NAVTEST_CASE_DECL(test_hal_uart_write_string_returns_ok);
 NAVTEST_CASE_DECL(test_hal_uart_print_generic_dispatch);
 NAVTEST_CASE_DECL(test_hal_uart_available_after_init_is_false);
+NAVTEST_CASE_DECL(test_hal_uart_attach_idle_rejects_null_cb);
+NAVTEST_CASE_DECL(test_hal_uart_attach_idle_sets_and_clears_idleie);
 
 
 static const navtest_case_t uart_protocol_cases[] = {
@@ -168,6 +193,8 @@ static const navtest_case_t uart_protocol_cases[] = {
     NAVTEST_CASE(test_hal_uart_write_string_returns_ok),
     NAVTEST_CASE(test_hal_uart_print_generic_dispatch),
     NAVTEST_CASE(test_hal_uart_available_after_init_is_false),
+    NAVTEST_CASE(test_hal_uart_attach_idle_rejects_null_cb),
+    NAVTEST_CASE(test_hal_uart_attach_idle_sets_and_clears_idleie),
 };
 
 const navtest_suite_t test_uart_protocol_suite = {

--- a/tests/arch/cortex-m4/test_uart_protocol.h
+++ b/tests/arch/cortex-m4/test_uart_protocol.h
@@ -50,6 +50,10 @@ void test_hal_uart_print_generic_dispatch(void);
 /* read surface */
 void test_hal_uart_available_after_init_is_false(void);
 
+/* idle-line callback surface */
+void test_hal_uart_attach_idle_rejects_null_cb(void);
+void test_hal_uart_attach_idle_sets_and_clears_idleie(void);
+
 extern const navtest_suite_t test_uart_protocol_suite;
 
 

--- a/tests/cap/sdio/test_sdio.c
+++ b/tests/cap/sdio/test_sdio.c
@@ -30,6 +30,7 @@
 
 #if NAVHAL_HAS_SDIO
 
+#include "family/sdio_reg.h"
 #include "navhal_port_sdio.h"
 #include "navtest/navtest.h"
 
@@ -73,12 +74,71 @@ void test_hal_sdio_set_callback_smoke(void) {
   hal_sdio_set_callback(NULL); /* re-clear */
   TEST_ASSERT_TRUE(1);
 }
+
+/* --- ISR clear-mask invariant -------------------------------------------- *
+ * Regression guard for an intermittent file-transfer stall: the SDIO data-
+ * completion ISR clears its transfer with SDIO_ICR_DATA_FLAGS and must NEVER
+ * clear the command-path flags (CMDREND in particular) that the synchronous
+ * send_command() poll is waiting on. For a fast single-block read the data
+ * phase can finish — firing the ISR — before a preempted poll has observed
+ * CMDREND; a blanket ICR = 0xFFFFFFFF in the ISR then erases CMDREND, the poll
+ * times out on a command that actually succeeded, and FatFS turns the spurious
+ * HAL_SDIO_TIMEOUT into FR_DISK_ERR and wedges. These are pure constant checks
+ * (no card, no peripheral state), so they hold on any board and in PIL. The
+ * expected sets below are re-derived from the individual bits — independent of
+ * the grouped macros — so a bad edit to either mask is actually caught. */
+#define EXPECT_DATA_CLEAR                                                       \
+  (SDIO_ICR_DCRCFAILC | SDIO_ICR_DTIMEOUTC | SDIO_ICR_TXUNDERRC |              \
+   SDIO_ICR_RXOVERRC | SDIO_ICR_DATAENDC | SDIO_ICR_STBITERRC |               \
+   SDIO_ICR_DBCKENDC)
+#define EXPECT_CMD_CLEAR                                                        \
+  (SDIO_ICR_CCRCFAILC | SDIO_ICR_CTIMEOUTC | SDIO_ICR_CMDRENDC |              \
+   SDIO_ICR_CMDSENTC)
+
+/* THE invariant: the data and command clear families share no bit, so an ISR
+ * writing SDIO_ICR_DATA_FLAGS cannot disturb any command flag. */
+void test_sdio_data_and_command_clear_masks_are_disjoint(void) {
+  TEST_ASSERT_EQUAL_UINT32(
+      0u, (uint32_t)(SDIO_ICR_DATA_FLAGS & SDIO_ICR_CMD_FLAGS));
+}
+
+/* Name the exact flag from the bug. */
+void test_sdio_cmdrend_not_in_data_clear(void) {
+  TEST_ASSERT_EQUAL_UINT32(0u,
+                           (uint32_t)(SDIO_ICR_DATA_FLAGS & SDIO_ICR_CMDRENDC));
+}
+
+/* Cover every data-path flag — a forgotten one leaves the DPSM flagged and
+ * wedges the next transfer instead. */
+void test_sdio_data_clear_covers_all_data_flags(void) {
+  TEST_ASSERT_EQUAL_UINT32((uint32_t)EXPECT_DATA_CLEAR,
+                           (uint32_t)SDIO_ICR_DATA_FLAGS);
+}
+
+/* The command clear is the complete complement, CMDREND included. */
+void test_sdio_command_clear_covers_all_command_flags(void) {
+  TEST_ASSERT_EQUAL_UINT32((uint32_t)EXPECT_CMD_CLEAR,
+                           (uint32_t)SDIO_ICR_CMD_FLAGS);
+}
+
+/* A blanket clear (0xFFFFFFFF) is the regression that caused the stall; an
+ * empty mask would never clear the transfer. Reject both. */
+void test_sdio_data_clear_is_not_a_blanket_clear(void) {
+  TEST_ASSERT_TRUE(SDIO_ICR_DATA_FLAGS != 0xFFFFFFFFu);
+  TEST_ASSERT_TRUE(SDIO_ICR_DATA_FLAGS != 0u);
+}
+
 /* PROGMEM slot for each case name on AVR; no-op elsewhere. */
 NAVTEST_CASE_DECL(test_hal_sdio_init_rejects_null_config);
 NAVTEST_CASE_DECL(test_hal_sdio_read_block_rejects_null_buffer);
 NAVTEST_CASE_DECL(test_hal_sdio_write_block_rejects_null_buffer);
 NAVTEST_CASE_DECL(test_hal_sdio_get_sector_count_returns_value);
 NAVTEST_CASE_DECL(test_hal_sdio_set_callback_smoke);
+NAVTEST_CASE_DECL(test_sdio_data_and_command_clear_masks_are_disjoint);
+NAVTEST_CASE_DECL(test_sdio_cmdrend_not_in_data_clear);
+NAVTEST_CASE_DECL(test_sdio_data_clear_covers_all_data_flags);
+NAVTEST_CASE_DECL(test_sdio_command_clear_covers_all_command_flags);
+NAVTEST_CASE_DECL(test_sdio_data_clear_is_not_a_blanket_clear);
 
 
 static const navtest_case_t sdio_cases[] = {
@@ -87,6 +147,11 @@ static const navtest_case_t sdio_cases[] = {
     NAVTEST_CASE(test_hal_sdio_write_block_rejects_null_buffer),
     NAVTEST_CASE(test_hal_sdio_get_sector_count_returns_value),
     NAVTEST_CASE(test_hal_sdio_set_callback_smoke),
+    NAVTEST_CASE(test_sdio_data_and_command_clear_masks_are_disjoint),
+    NAVTEST_CASE(test_sdio_cmdrend_not_in_data_clear),
+    NAVTEST_CASE(test_sdio_data_clear_covers_all_data_flags),
+    NAVTEST_CASE(test_sdio_command_clear_covers_all_command_flags),
+    NAVTEST_CASE(test_sdio_data_clear_is_not_a_blanket_clear),
 };
 
 const navtest_suite_t test_sdio_suite = {

--- a/tests/cap/sdio/test_sdio.h
+++ b/tests/cap/sdio/test_sdio.h
@@ -41,6 +41,11 @@ void test_hal_sdio_read_block_rejects_null_buffer(void);
 void test_hal_sdio_write_block_rejects_null_buffer(void);
 void test_hal_sdio_get_sector_count_returns_value(void);
 void test_hal_sdio_set_callback_smoke(void);
+void test_sdio_data_and_command_clear_masks_are_disjoint(void);
+void test_sdio_cmdrend_not_in_data_clear(void);
+void test_sdio_data_clear_covers_all_data_flags(void);
+void test_sdio_command_clear_covers_all_command_flags(void);
+void test_sdio_data_clear_is_not_a_blanket_clear(void);
 
 extern const navtest_suite_t test_sdio_suite;
 


### PR DESCRIPTION
## Why

`main` (`0.3.1-dev`) and `stable` had **forked** — 20 fix/feature commits landed on `stable` and were never brought forward. As a result `main` was missing `hal_cpu_idle()` (which vaios calls at `task.c:407`) **and** a batch of genuine bug fixes. This back-merges `stable` into `main` to reconcile the two lines.

It is *not* a rename — the symbol simply never existed on `main`. And it was not alone: cherry-picking one function would have left 19 other fixes stranded.

## Notable fixes now on main

- `feat(interrupt)`: `hal_cpu_idle()` — WFI idle primitive (cortex-m4)
- `fix(sdio)`: data-completion ISR clears only data flags, never CMDREND (intermittent `FR_DISK_ERR` stall)
- `fix(clock)`: bound the RCC ready/switch waits so bring-up can't hang
- `fix(uart)`: USART6 TX DMA moved to Stream7 (SDIO owns Stream6)
- `fix(v_fs)`: free the descriptor slot even when `f_close` errors (fd leak)
- `feat(i2c)`: restore `hal_i2c_deinit`; `feat(uart)`: IDLE-line RX event; `feat(v_fs)`: `v_stat` + `v_opendir/readdir/closedir`

## Conflict resolutions (5 files)

- **navhal.h / CMakeLists.txt** version → kept main's `0.3.1-dev` (the dev line; stable's fixes fold into it).
- **sdio.c `hal_sdio_read_blocks_async`** → took stable's *arm-before-trigger* rewrite; main still had the old CMD18-first order that stable fixed for the DPSM start-bit race.
- **tests/cap/sdio** → **unioned** both sides: main's PIL round-trip + stable's ISR clear-mask regression guards.
- **F7 `sdio_reg.h`** → ported stable's `SDIO_ICR_DATA_FLAGS` / `SDIO_ICR_CMD_FLAGS` grouped masks. The merged shared `sdio.c` and the stable tests reference them, but stable only defined them on its F4 SDIO target; main's newer F7 SDIO port lacked them — without this the **F7 build itself** would not compile.

## Verified locally (all arches)

| Tier | Result |
|---|---|
| host / SIL | 24/24 + 62/62 |
| F767 PIL | **173/173** (+5 SDIO ISR tests now compile on F7) |
| F401 PIL | 158/158 |
| atmega PIL | 36/36 |

Unblocks vaios once it depends on this (`hal_cpu_idle` present on main). Note the `hal_cpu_idle` declaration is cortex-m4-only, mirroring stable; the shared armv7e-m impl compiles for M7 too.